### PR TITLE
End process when calling exit

### DIFF
--- a/newlib/libc/sys/vita/syscalls.c
+++ b/newlib/libc/sys/vita/syscalls.c
@@ -39,6 +39,7 @@ void
 _exit(int rc)
 {
 	_free_vita_newlib();
+	sceKernelExitProcess(rc);
 }
 
 int


### PR DESCRIPTION
@yifanlu removed the UVL calls when de-hackifying newlib, but didn't put back any actual process-ending call in `_exit`, making processes crash when they run off the stack.
