### PR TITLE
Add sys/errno.h

### DIFF
--- a/newlib/libc/sys/vita/Makefile.am
+++ b/newlib/libc/sys/vita/Makefile.am
@@ -8,17 +8,17 @@ AM_CCASFLAGS = $(INCLUDES)
 
 noinst_LIBRARIES = lib.a
 
-SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o netdb.o
+SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o netdb.o error.o
 DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
 
-lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c dirent.c
+lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c error.c dirent.c
 lib_a_LIBADD = ${SOCKET_OBJS} ${DIRENT_OBJS}
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
 
 all-local: crt0.o
 
-$(SOCKET_OBJS): socket.c netdb.c
+$(SOCKET_OBJS): socket.c netdb.c error.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
 $(DIRENT_OBJS): dirent.c

--- a/newlib/libc/sys/vita/Makefile.in
+++ b/newlib/libc/sys/vita/Makefile.in
@@ -73,7 +73,7 @@ am_lib_a_OBJECTS = lib_a-syscalls.$(OBJEXT) lib_a-sbrk.$(OBJEXT) \
 	lib_a-threading.$(OBJEXT) lib_a-mlock.$(OBJEXT) \
 	lib_a-io.$(OBJEXT) lib_a-socket.$(OBJEXT) lib_a-dup.$(OBJEXT) \
 	lib_a-select.$(OBJEXT) lib_a-netdb.$(OBJEXT) \
-	lib_a-dirent.$(OBJEXT)
+	lib_a-error.$(OBJEXT) lib_a-dirent.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
@@ -198,9 +198,9 @@ AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
-SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o netdb.o
+SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o netdb.o error.o
 DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
-lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c dirent.c
+lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c error.c dirent.c
 lib_a_LIBADD = ${SOCKET_OBJS} ${DIRENT_OBJS}
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
@@ -317,6 +317,12 @@ lib_a-netdb.o: netdb.c
 
 lib_a-netdb.obj: netdb.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-netdb.obj `if test -f 'netdb.c'; then $(CYGPATH_W) 'netdb.c'; else $(CYGPATH_W) '$(srcdir)/netdb.c'; fi`
+
+lib_a-error.o: error.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-error.o `test -f 'error.c' || echo '$(srcdir)/'`error.c
+
+lib_a-error.obj: error.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-error.obj `if test -f 'error.c'; then $(CYGPATH_W) 'error.c'; else $(CYGPATH_W) '$(srcdir)/error.c'; fi`
 
 lib_a-dirent.o: dirent.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-dirent.o `test -f 'dirent.c' || echo '$(srcdir)/'`dirent.c
@@ -497,7 +503,7 @@ uninstall-am:
 
 all-local: crt0.o
 
-$(SOCKET_OBJS): socket.c netdb.c
+$(SOCKET_OBJS): socket.c netdb.c error.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
 $(DIRENT_OBJS): dirent.c

--- a/newlib/libc/sys/vita/error.c
+++ b/newlib/libc/sys/vita/error.c
@@ -200,6 +200,6 @@ int __vita_sce_errno_to_errno(int sce_errno)
 		case SCE_NET_ERROR_ETIME:
 			return ETIME;
 		default:
-			return EINVAL;
+			return sce_errno;
 	}
 }

--- a/newlib/libc/sys/vita/error.c
+++ b/newlib/libc/sys/vita/error.c
@@ -1,0 +1,204 @@
+/*
+
+Copyright (C) 2018, Sunguk Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+*/
+#include <errno.h>
+
+#include <psp2/net/net.h>
+
+#include "vitaerror.h"
+
+int __vita_sce_errno_to_errno(int sce_errno)
+{
+	switch (sce_errno)
+	{
+		case SCE_NET_ERROR_EPERM:
+			return EPERM;
+		case SCE_NET_ERROR_ENOENT:
+			return ENOENT;
+		case SCE_NET_ERROR_ESRCH:
+			return ESRCH;
+		case SCE_NET_ERROR_EINTR:
+			return EINTR;
+		case SCE_NET_ERROR_EIO:
+			return EIO;
+		case SCE_NET_ERROR_ENXIO:
+			return ENXIO;
+		case SCE_NET_ERROR_E2BIG:
+			return E2BIG;
+		case SCE_NET_ERROR_ENOEXEC:
+			return ENOEXEC;
+		case SCE_NET_ERROR_EBADF:
+			return EBADF;
+		case SCE_NET_ERROR_ECHILD:
+			return ECHILD;
+		case SCE_NET_ERROR_EDEADLK:
+			return EDEADLK;
+		case SCE_NET_ERROR_ENOMEM:
+			return ENOMEM;
+		case SCE_NET_ERROR_EACCES:
+			return EACCES;
+		case SCE_NET_ERROR_EFAULT:
+			return EFAULT;
+		case SCE_NET_ERROR_ENOTBLK:
+			return ENOTBLK;
+		case SCE_NET_ERROR_EBUSY:
+			return EBUSY;
+		case SCE_NET_ERROR_EEXIST:
+			return EEXIST;
+		case SCE_NET_ERROR_EXDEV:
+			return EXDEV;
+		case SCE_NET_ERROR_ENODEV:
+			return ENODEV;
+		case SCE_NET_ERROR_ENOTDIR:
+			return ENOTDIR;
+		case SCE_NET_ERROR_EISDIR:
+			return EISDIR;
+		case SCE_NET_ERROR_EINVAL:
+			return EINVAL;
+		case SCE_NET_ERROR_ENFILE:
+			return ENFILE;
+		case SCE_NET_ERROR_EMFILE:
+			return EMFILE;
+		case SCE_NET_ERROR_ENOTTY:
+			return ENOTTY;
+		case SCE_NET_ERROR_ETXTBSY:
+			return ETXTBSY;
+		case SCE_NET_ERROR_EFBIG:
+			return EFBIG;
+		case SCE_NET_ERROR_ENOSPC:
+			return ENOSPC;
+		case SCE_NET_ERROR_ESPIPE:
+			return ESPIPE;
+		case SCE_NET_ERROR_EROFS:
+			return EROFS;
+		case SCE_NET_ERROR_EMLINK:
+			return EMLINK;
+		case SCE_NET_ERROR_EPIPE:
+			return EPIPE;
+		case SCE_NET_ERROR_EDOM:
+			return EDOM;
+		case SCE_NET_ERROR_ERANGE:
+			return ERANGE;
+		case SCE_NET_ERROR_EAGAIN:
+			return EAGAIN;
+// these values are the same as EAGAIN
+//		case SCE_NET_ERROR_EWOULDBLOCK:
+//			return EWOULDBLOCK;
+		case SCE_NET_ERROR_EINPROGRESS:
+			return EINPROGRESS;
+		case SCE_NET_ERROR_EALREADY:
+			return EALREADY;
+		case SCE_NET_ERROR_ENOTSOCK:
+			return ENOTSOCK;
+		case SCE_NET_ERROR_EDESTADDRREQ:
+			return EDESTADDRREQ;
+		case SCE_NET_ERROR_EMSGSIZE:
+			return EMSGSIZE;
+		case SCE_NET_ERROR_EPROTOTYPE:
+			return EPROTOTYPE;
+		case SCE_NET_ERROR_ENOPROTOOPT:
+			return ENOPROTOOPT;
+		case SCE_NET_ERROR_EPROTONOSUPPORT:
+			return EPROTONOSUPPORT;
+		case SCE_NET_ERROR_ESOCKTNOSUPPORT:
+			return ESOCKTNOSUPPORT;
+		case SCE_NET_ERROR_EOPNOTSUPP:
+			return EOPNOTSUPP;
+		case SCE_NET_ERROR_EPFNOSUPPORT:
+			return EPFNOSUPPORT;
+		case SCE_NET_ERROR_EAFNOSUPPORT:
+			return EAFNOSUPPORT;
+		case SCE_NET_ERROR_EADDRINUSE:
+			return EADDRINUSE;
+		case SCE_NET_ERROR_EADDRNOTAVAIL:
+			return EADDRNOTAVAIL;
+		case SCE_NET_ERROR_ENETDOWN:
+			return ENETDOWN;
+		case SCE_NET_ERROR_ENETUNREACH:
+			return ENETUNREACH;
+		case SCE_NET_ERROR_ENETRESET:
+			return ENETRESET;
+		case SCE_NET_ERROR_ECONNABORTED:
+			return ECONNABORTED;
+		case SCE_NET_ERROR_ECONNRESET:
+			return ECONNRESET;
+		case SCE_NET_ERROR_ENOBUFS:
+			return ENOBUFS;
+		case SCE_NET_ERROR_EISCONN:
+			return EISCONN;
+		case SCE_NET_ERROR_ENOTCONN:
+			return ENOTCONN;
+		case SCE_NET_ERROR_ESHUTDOWN:
+			return ESHUTDOWN;
+		case SCE_NET_ERROR_ETOOMANYREFS:
+			return ETOOMANYREFS;
+		case SCE_NET_ERROR_ETIMEDOUT:
+			return ETIMEDOUT;
+		case SCE_NET_ERROR_ECONNREFUSED:
+			return ECONNREFUSED;
+		case SCE_NET_ERROR_ELOOP:
+			return ELOOP;
+		case SCE_NET_ERROR_ENAMETOOLONG:
+			return ENAMETOOLONG;
+		case SCE_NET_ERROR_EHOSTDOWN:
+			return EHOSTDOWN;
+		case SCE_NET_ERROR_EHOSTUNREACH:
+			return EHOSTUNREACH;
+		case SCE_NET_ERROR_ENOTEMPTY:
+			return ENOTEMPTY;
+		case SCE_NET_ERROR_EUSERS:
+			return EUSERS;
+		case SCE_NET_ERROR_EDQUOT:
+			return EDQUOT;
+		case SCE_NET_ERROR_ESTALE:
+			return ESTALE;
+		case SCE_NET_ERROR_EREMOTE:
+			return EREMOTE;
+		case SCE_NET_ERROR_ENOLCK:
+			return ENOLCK;
+		case SCE_NET_ERROR_ENOSYS:
+			return ENOSYS;
+		case SCE_NET_ERROR_EIDRM:
+			return EIDRM;
+		case SCE_NET_ERROR_EOVERFLOW:
+			return EOVERFLOW;
+		case SCE_NET_ERROR_EILSEQ:
+			return EILSEQ;
+		case SCE_NET_ERROR_ENOTSUP:
+			return ENOTSUP;
+		case SCE_NET_ERROR_ECANCELED:
+			return ECANCELED;
+		case SCE_NET_ERROR_EBADMSG:
+			return EBADMSG;
+		case SCE_NET_ERROR_ENODATA:
+			return ENODATA;
+		case SCE_NET_ERROR_ENOSR:
+			return ENOSR;
+		case SCE_NET_ERROR_ENOSTR:
+			return ENOSTR;
+		case SCE_NET_ERROR_ETIME:
+			return ETIME;
+		default:
+			return EINVAL;
+	}
+}

--- a/newlib/libc/sys/vita/error.c
+++ b/newlib/libc/sys/vita/error.c
@@ -1,5 +1,6 @@
 /*
 
+Copyright (C) 2017, David "Davee" Morgan
 Copyright (C) 2018, Sunguk Lee
 
 Permission is hereby granted, free of charge, to any person obtaining a

--- a/newlib/libc/sys/vita/select.c
+++ b/newlib/libc/sys/vita/select.c
@@ -32,8 +32,7 @@ DEALINGS IN THE SOFTWARE.
 #include <psp2/types.h>
 
 #include "vitadescriptor.h"
-
-#define SCE_ERRNO_MASK 0xFF
+#include "vitaerror.h"
 
 #define MAX_EVENTS 255
 
@@ -56,7 +55,7 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 
 	int eid = sceNetEpollCreate("", 0);
 	if (eid < 0) {
-		errno = eid & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(eid);
 		return -1;
 	}
 
@@ -96,7 +95,7 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 	int res = 0;
 
 	if (nev < 0) {
-		errno = nev & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(nev);
 		res = -1;
 		goto exit;
 	}

--- a/newlib/libc/sys/vita/socket.c
+++ b/newlib/libc/sys/vita/socket.c
@@ -30,8 +30,7 @@ DEALINGS IN THE SOFTWARE.
 #include <psp2/types.h>
 
 #include "vitadescriptor.h"
-
-#define SCE_ERRNO_MASK 0xFF
+#include "vitaerror.h"
 
 static inline int is_socket_valid(int s)
 {
@@ -55,7 +54,7 @@ int accept(int s, struct sockaddr *addr, socklen_t *addrlen)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -90,7 +89,7 @@ int	bind(int s, const struct sockaddr *addr, socklen_t addrlen)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -115,7 +114,7 @@ int	connect(int s, const struct sockaddr *addr, socklen_t addrlen)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -140,7 +139,7 @@ int	getpeername(int s, struct sockaddr *addr, socklen_t *addrlen)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -165,7 +164,7 @@ int	getsockname(int s, struct sockaddr *addr, socklen_t *addrlen)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -190,7 +189,7 @@ int	getsockopt(int s, int level, int optname, void *optval, socklen_t *optlen)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -215,7 +214,7 @@ int	listen(int s, int backlog)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -240,7 +239,7 @@ ssize_t	recv(int s, void *buf, size_t len, int flags)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -266,7 +265,7 @@ ssize_t	recvfrom(int s, void *buf, size_t len, int flags,
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -291,7 +290,7 @@ ssize_t recvmsg(int s, struct msghdr *msg, int flags)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -316,7 +315,7 @@ ssize_t	send(int s, const void *buf, size_t len, int flags)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -343,7 +342,7 @@ ssize_t	sendto(int s, const void *buf,
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -368,7 +367,7 @@ ssize_t sendmsg(int s, const struct msghdr *msg, int flags)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -407,7 +406,7 @@ int	setsockopt(int s, int level, int optname, const void *optval, socklen_t optl
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -432,7 +431,7 @@ int	shutdown(int s, int how)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -447,7 +446,7 @@ int	socket(int domain, int type, int protocol)
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res);
 		return -1;
 	}
 
@@ -466,16 +465,19 @@ int	socket(int domain, int type, int protocol)
 
 int __vita_glue_socket_close(SceUID scefd)
 {
-	return sceNetSocketClose(scefd);
+	int res = sceNetSocketClose(scefd);
+	return res >= 0 ? res : __vita_sce_errno_to_errno(res);
 }
 
 ssize_t __vita_glue_socket_recv(SceUID scefd, void *buf, size_t len, int flags)
 {
-	return sceNetRecv(scefd, buf, len, flags);
+	int res = sceNetRecv(scefd, buf, len, flags);
+	return res >= 0 ? res : __vita_sce_errno_to_errno(res);
 }
 
 ssize_t	__vita_glue_socket_send(SceUID scefd, const void *buf, size_t len, int flags)
 {
-	return sceNetSend(scefd, buf, len, flags);
+	int res = sceNetSend(scefd, buf, len, flags);
+	return res >= 0 ? res : __vita_sce_errno_to_errno(res);
 }
 #endif

--- a/newlib/libc/sys/vita/sys/errno.h
+++ b/newlib/libc/sys/vita/sys/errno.h
@@ -1,0 +1,140 @@
+/* errno is not a global variable, because that would make using it
+   non-reentrant.  Instead, its address is returned by the function
+   __errno.  */
+
+#ifndef _SYS_ERRNO_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define _SYS_ERRNO_H_
+
+#include <sys/reent.h>
+
+#ifndef _REENT_ONLY
+#define errno (*__errno())
+extern int *__errno _PARAMS ((void));
+#endif
+
+/* Please don't use these variables directly.
+   Use strerror instead. */
+extern __IMPORT _CONST char * _CONST _sys_errlist[];
+extern __IMPORT int _sys_nerr;
+
+#define __errno_r(ptr) ((ptr)->_errno)
+
+#define EPERM           1   /* Not owner */
+#define ENOENT          2   /* No such file or directory */
+#define ESRCH           3   /* No such process */
+#define EINTR           4   /* Interrupted system call */
+#define EIO             5   /* I/O error */
+#define ENXIO           6   /* No such device or address */
+#define E2BIG           7   /* Arg list too long */
+#define ENOEXEC         8   /* Exec format error */
+#define EBADF           9   /* Bad file number */
+#define ECHILD          10  /* No children */
+#define EAGAIN          35  /* No more processes */
+#define ENOMEM          12  /* Not enough space */
+#define EACCES          13  /* Permission denied */
+#define EFAULT          14  /* Bad address */
+#define ENOTBLK         15  /* Block device required */
+#define EBUSY           16  /* Device or resource busy */
+#define EEXIST          17  /* File exists */
+#define EXDEV           18  /* Cross-device link */
+#define ENODEV          19  /* No such device */
+#define ENOTDIR         20  /* Not a directory */
+#define EISDIR          21  /* Is a directory */
+#define EINVAL          22  /* Invalid argument */
+#define ENFILE          23  /* Too many open files in system */
+#define EMFILE          24  /* File descriptor value too large */
+#define ENOTTY          25  /* Not a character device */
+#define ETXTBSY         26  /* Text file busy */
+#define EFBIG           27  /* File too large */
+#define ENOSPC          28  /* No space left on device */
+#define ESPIPE          29  /* Illegal seek */
+#define EROFS           30  /* Read-only file system */
+#define EMLINK          31  /* Too many links */
+#define EPIPE           32  /* Broken pipe */
+#define EDOM            33  /* Mathematics argument out of domain of function */
+#define ERANGE          34  /* Result too large */
+#define ENOMSG          83  /* No message of desired type */
+#define EIDRM           82  /* Identifier removed */
+#define EDEADLK         11  /* Deadlock */
+#define ENOLCK          77  /* No lock */
+#define ENOSTR          91  /* Not a stream */
+#define ENODATA         89  /* No data (for no delay io) */
+#define ETIME           92  /* Stream ioctl timeout */
+#define ENOSR           90  /* No stream resources */
+#define EREMOTE         71  /* The object is remote */
+// TODO: check value
+#define ENOLINK         91  /* Virtual circuit is gone */
+// TODO: check value
+#define EPROTO          92  /* Protocol error */
+// TODO: check value
+#define EMULTIHOP       90  /* Multihop attempted */
+#define EBADMSG         88  /* Bad message */
+#define EFTYPE          79  /* Inappropriate file type or format */
+#define ENOSYS          78  /* Function not implemented */
+#define ENOTEMPTY       66  /* Directory not empty */
+// TODO: check value
+#define ENAMETOOLONG    63  /* File or path name too long */
+// TODO: check value
+#define ELOOP           62  /* Too many symbolic links */
+#define EOPNOTSUPP      45  /* Operation not supported on socket */
+#define EPFNOSUPPORT    46  /* Protocol family not supported */
+#define ECONNRESET      54  /* Connection reset by peer */
+#define ENOBUFS         55  /* No buffer space available */
+#define EAFNOSUPPORT    47  /* Address family not supported by protocol family */
+#define EPROTOTYPE      41  /* Protocol wrong type for socket */
+#define ENOTSOCK        38  /* Socket operation on non-socket */
+#define ENOPROTOOPT     42  /* Protocol not available */
+#define ESHUTDOWN       58  /* Can't send after socket shutdown */
+#define ECONNREFUSED    61  /* Connection refused */
+#define EADDRINUSE      48  /* Address already in use */
+#define ECONNABORTED    53  /* Software caused connection abort */
+#define ENETUNREACH     51  /* Network is unreachable */
+#define ENETDOWN        50  /* Network interface is not configured */
+#define ETIMEDOUT       60  /* Connection timed out */
+#define EHOSTDOWN       64  /* Host is down */
+#define EHOSTUNREACH    65  /* Host is unreachable */
+#define EINPROGRESS     36  /* Connection already in progress */
+#define EALREADY        37  /* Socket already connected */
+#define EDESTADDRREQ    39  /* Destination address required */
+#define EMSGSIZE        40  /* Message too long */
+#define EPROTONOSUPPORT 43  /* Unknown protocol */
+#define ESOCKTNOSUPPORT 44  /* Socket type not supported */
+#define EADDRNOTAVAIL   49  /* Address not available */
+#define ENETRESET       52  /* Connection aborted by network */
+#define EISCONN         56  /* Socket is already connected */
+#define ENOTCONN        57  /* Socket is not connected */
+#define ETOOMANYREFS    59
+#define EPROCLIM        67
+#define EUSERS          68
+#define EDQUOT          69
+#define ESTALE          70
+#define ENOTSUP         86  /* Not supported */
+#define EILSEQ          85  /* Illegal byte sequence */
+#define EOVERFLOW       84  /* Value too large for defined data type */
+#define ECANCELED       87  /* Operation canceled */
+// TODO: check value
+#define ENOTRECOVERABLE 95  /* State not recoverable */
+// TODO: check value
+#define EOWNERDEAD      96  /* Previous owner died */
+
+#define EBADRPC         72
+#define ERPCMISMATCH    73
+#define EPROGUNAVAIL    74
+#define EPROGMISMATCH   75
+#define EPROCUNAVAIL    76
+#define EAUTH           80
+#define ENEEDAUTH       81
+#define EADHOC          160
+#define EDISABLEDIF     161
+#define ERESUME         162
+#define EWOULDBLOCK     EAGAIN /* Operation would block */
+
+#define __ELASTERROR    2000 /* Users can add values starting here */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _SYS_ERRNO_H */

--- a/newlib/libc/sys/vita/sys/errno.h
+++ b/newlib/libc/sys/vita/sys/errno.h
@@ -26,7 +26,7 @@ extern __IMPORT int _sys_nerr;
 #define ENOENT		2	/* No such file or directory */
 #define ESRCH		3	/* No such process */
 #define EINTR		4	/* Interrupted system call */
-#define EIO			5	/* I/O error */
+#define EIO		5	/* I/O error */
 #define ENXIO		6	/* No such device or address */
 #define E2BIG		7	/* Arg list too long */
 #define ENOEXEC		8	/* Exec format error */

--- a/newlib/libc/sys/vita/sys/errno.h
+++ b/newlib/libc/sys/vita/sys/errno.h
@@ -58,8 +58,8 @@ extern __IMPORT int _sys_nerr;
 #define ERANGE		34	/* Result too large */
 #define ENOMSG		35	/* No message of desired type */
 #define EIDRM		36	/* Identifier removed */
-#define edeadlk		45	/* deadlock */
-#define enolck		46	/* no lock */
+#define EDEADLK		45	/* deadlock */
+#define ENOLCK		46	/* no lock */
 #define ENOSTR		60	/* Not a stream */
 #define ENODATA		61	/* No data (for no delay io) */
 #define ETIME		62	/* Stream ioctl timeout */

--- a/newlib/libc/sys/vita/sys/errno.h
+++ b/newlib/libc/sys/vita/sys/errno.h
@@ -22,117 +22,98 @@ extern __IMPORT int _sys_nerr;
 
 #define __errno_r(ptr) ((ptr)->_errno)
 
-#define EPERM           1   /* Not owner */
-#define ENOENT          2   /* No such file or directory */
-#define ESRCH           3   /* No such process */
-#define EINTR           4   /* Interrupted system call */
-#define EIO             5   /* I/O error */
-#define ENXIO           6   /* No such device or address */
-#define E2BIG           7   /* Arg list too long */
-#define ENOEXEC         8   /* Exec format error */
-#define EBADF           9   /* Bad file number */
-#define ECHILD          10  /* No children */
-#define EAGAIN          35  /* No more processes */
-#define ENOMEM          12  /* Not enough space */
-#define EACCES          13  /* Permission denied */
-#define EFAULT          14  /* Bad address */
-#define ENOTBLK         15  /* Block device required */
-#define EBUSY           16  /* Device or resource busy */
-#define EEXIST          17  /* File exists */
-#define EXDEV           18  /* Cross-device link */
-#define ENODEV          19  /* No such device */
-#define ENOTDIR         20  /* Not a directory */
-#define EISDIR          21  /* Is a directory */
-#define EINVAL          22  /* Invalid argument */
-#define ENFILE          23  /* Too many open files in system */
-#define EMFILE          24  /* File descriptor value too large */
-#define ENOTTY          25  /* Not a character device */
-#define ETXTBSY         26  /* Text file busy */
-#define EFBIG           27  /* File too large */
-#define ENOSPC          28  /* No space left on device */
-#define ESPIPE          29  /* Illegal seek */
-#define EROFS           30  /* Read-only file system */
-#define EMLINK          31  /* Too many links */
-#define EPIPE           32  /* Broken pipe */
-#define EDOM            33  /* Mathematics argument out of domain of function */
-#define ERANGE          34  /* Result too large */
-#define ENOMSG          83  /* No message of desired type */
-#define EIDRM           82  /* Identifier removed */
-#define EDEADLK         11  /* Deadlock */
-#define ENOLCK          77  /* No lock */
-#define ENOSTR          91  /* Not a stream */
-#define ENODATA         89  /* No data (for no delay io) */
-#define ETIME           92  /* Stream ioctl timeout */
-#define ENOSR           90  /* No stream resources */
-#define EREMOTE         71  /* The object is remote */
-// TODO: check value
-#define ENOLINK         91  /* Virtual circuit is gone */
-// TODO: check value
-#define EPROTO          92  /* Protocol error */
-// TODO: check value
-#define EMULTIHOP       90  /* Multihop attempted */
-#define EBADMSG         88  /* Bad message */
-#define EFTYPE          79  /* Inappropriate file type or format */
-#define ENOSYS          78  /* Function not implemented */
-#define ENOTEMPTY       66  /* Directory not empty */
-// TODO: check value
-#define ENAMETOOLONG    63  /* File or path name too long */
-// TODO: check value
-#define ELOOP           62  /* Too many symbolic links */
-#define EOPNOTSUPP      45  /* Operation not supported on socket */
-#define EPFNOSUPPORT    46  /* Protocol family not supported */
-#define ECONNRESET      54  /* Connection reset by peer */
-#define ENOBUFS         55  /* No buffer space available */
-#define EAFNOSUPPORT    47  /* Address family not supported by protocol family */
-#define EPROTOTYPE      41  /* Protocol wrong type for socket */
-#define ENOTSOCK        38  /* Socket operation on non-socket */
-#define ENOPROTOOPT     42  /* Protocol not available */
-#define ESHUTDOWN       58  /* Can't send after socket shutdown */
-#define ECONNREFUSED    61  /* Connection refused */
-#define EADDRINUSE      48  /* Address already in use */
-#define ECONNABORTED    53  /* Software caused connection abort */
-#define ENETUNREACH     51  /* Network is unreachable */
-#define ENETDOWN        50  /* Network interface is not configured */
-#define ETIMEDOUT       60  /* Connection timed out */
-#define EHOSTDOWN       64  /* Host is down */
-#define EHOSTUNREACH    65  /* Host is unreachable */
-#define EINPROGRESS     36  /* Connection already in progress */
-#define EALREADY        37  /* Socket already connected */
-#define EDESTADDRREQ    39  /* Destination address required */
-#define EMSGSIZE        40  /* Message too long */
-#define EPROTONOSUPPORT 43  /* Unknown protocol */
-#define ESOCKTNOSUPPORT 44  /* Socket type not supported */
-#define EADDRNOTAVAIL   49  /* Address not available */
-#define ENETRESET       52  /* Connection aborted by network */
-#define EISCONN         56  /* Socket is already connected */
-#define ENOTCONN        57  /* Socket is not connected */
-#define ETOOMANYREFS    59
-#define EPROCLIM        67
-#define EUSERS          68
-#define EDQUOT          69
-#define ESTALE          70
-#define ENOTSUP         86  /* Not supported */
-#define EILSEQ          85  /* Illegal byte sequence */
-#define EOVERFLOW       84  /* Value too large for defined data type */
-#define ECANCELED       87  /* Operation canceled */
-// TODO: check value
-#define ENOTRECOVERABLE 95  /* State not recoverable */
-// TODO: check value
-#define EOWNERDEAD      96  /* Previous owner died */
+#define EPERM		1	/* Not owner */
+#define ENOENT		2	/* No such file or directory */
+#define ESRCH		3	/* No such process */
+#define EINTR		4	/* Interrupted system call */
+#define EIO			5	/* I/O error */
+#define ENXIO		6	/* No such device or address */
+#define E2BIG		7	/* Arg list too long */
+#define ENOEXEC		8	/* Exec format error */
+#define EBADF		9	/* Bad file number */
+#define ECHILD		10	/* No children */
+#define EAGAIN		11	/* No more processes */
+#define ENOMEM		12	/* Not enough space */
+#define EACCES		13	/* Permission denied */
+#define EFAULT		14	/* Bad address */
+#define ENOTBLK		15	/* Block device required */
+#define EBUSY		16	/* Device or resource busy */
+#define EEXIST		17	/* File exists */
+#define EXDEV		18	/* Cross-device link */
+#define ENODEV		19	/* No such device */
+#define ENOTDIR		20	/* Not a directory */
+#define EISDIR		21	/* Is a directory */
+#define EINVAL		22	/* Invalid argument */
+#define ENFILE		23	/* Too many open files in system */
+#define EMFILE		24	/* File descriptor value too large */
+#define ENOTTY		25	/* Not a character device */
+#define ETXTBSY		26	/* Text file busy */
+#define EFBIG		27	/* File too large */
+#define ENOSPC		28	/* No space left on device */
+#define ESPIPE		29	/* Illegal seek */
+#define EROFS		30	/* Read-only file system */
+#define EMLINK		31	/* Too many links */
+#define EPIPE		32	/* Broken pipe */
+#define EDOM		33	/* Mathematics argument out of domain of function */
+#define ERANGE		34	/* Result too large */
+#define ENOMSG		35	/* No message of desired type */
+#define EIDRM		36	/* Identifier removed */
+#define edeadlk		45	/* deadlock */
+#define enolck		46	/* no lock */
+#define ENOSTR		60	/* Not a stream */
+#define ENODATA		61	/* No data (for no delay io) */
+#define ETIME		62	/* Stream ioctl timeout */
+#define ENOSR		63	/* No stream resources */
+#define EREMOTE		66	/* The object is remote */
+#define ENOLINK		67	/* Virtual circuit is gone */
+#define EPROTO		71	/* Protocol error */
+#define EMULTIHOP	74	/* Multihop attempted */
+#define EBADMSG		77	/* Bad message */
+#define EFTYPE		79	/* Inappropriate file type or format */
+#define ENOSYS		88	/* Function not implemented */
+#define ENOTEMPTY	90	/* Directory not empty */
+#define ENAMETOOLONG	91	/* File or path name too long */
+#define ELOOP		92	/* Too many symbolic links */
+#define EOPNOTSUPP	95	/* Operation not supported on socket */
+#define EPFNOSUPPORT	96	/* Protocol family not supported */
+#define ECONNRESET	104	/* Connection reset by peer */
+#define ENOBUFS		105	/* No buffer space available */
+#define EAFNOSUPPORT	106	/* Address family not supported by protocol family */
+#define EPROTOTYPE	107	/* Protocol wrong type for socket */
+#define ENOTSOCK	108	/* Socket operation on non-socket */
+#define ENOPROTOOPT	109	/* Protocol not available */
+#define ESHUTDOWN	110	/* Can't send after socket shutdown */
+#define ECONNREFUSED	111	/* Connection refused */
+#define EADDRINUSE	112	/* Address already in use */
+#define ECONNABORTED	113	/* Software caused connection abort */
+#define ENETUNREACH	114	/* Network is unreachable */
+#define ENETDOWN	115	/* Network interface is not configured */
+#define ETIMEDOUT	116	/* Connection timed out */
+#define EHOSTDOWN	117	/* Host is down */
+#define EHOSTUNREACH	118	/* Host is unreachable */
+#define EINPROGRESS	119	/* Connection already in progress */
+#define EALREADY	120	/* Socket already connected */
+#define EDESTADDRREQ	121	/* Destination address required */
+#define EMSGSIZE	122	/* Message too long */
+#define EPROTONOSUPPORT	123	/* Unknown protocol */
+#define ESOCKTNOSUPPORT	124	/* Socket type not supported */
+#define EADDRNOTAVAIL	125	/* Address not available */
+#define ENETRESET	126	/* Connection aborted by network */
+#define EISCONN		127	/* Socket is already connected */
+#define ENOTCONN	128	/* Socket is not connected */
+#define ETOOMANYREFS	129
+#define EUSERS		131
+#define EDQUOT		132
+#define ESTALE		133
+#define ENOTSUP		134	/* Not supported */
+#define EILSEQ		138	/* Illegal byte sequence */
+#define EOVERFLOW	139	/* Value too large for defined data type */
+#define ECANCELED	140	/* Operation canceled */
+#define ENOTRECOVERABLE	141	/* State not recoverable */
+#define EOWNERDEAD	142	/* Previous owner died */
+#define EWOULDBLOCK	EAGAIN	/* Operation would block */
 
-#define EBADRPC         72
-#define ERPCMISMATCH    73
-#define EPROGUNAVAIL    74
-#define EPROGMISMATCH   75
-#define EPROCUNAVAIL    76
-#define EAUTH           80
-#define ENEEDAUTH       81
-#define EADHOC          160
-#define EDISABLEDIF     161
-#define ERESUME         162
-#define EWOULDBLOCK     EAGAIN /* Operation would block */
-
-#define __ELASTERROR    2000 /* Users can add values starting here */
+#define __ELASTERROR	2000	/* Users can add values starting here */
 
 #ifdef __cplusplus
 }

--- a/newlib/libc/sys/vita/syscalls.c
+++ b/newlib/libc/sys/vita/syscalls.c
@@ -19,6 +19,7 @@
 
 #include "vitadescriptor.h"
 #include "vitaglue.h"
+#include "vitaerror.h"
 
 
 // TODO: add to SDK

--- a/newlib/libc/sys/vita/vitaerror.h
+++ b/newlib/libc/sys/vita/vitaerror.h
@@ -1,0 +1,32 @@
+/*
+
+Copyright (C) 2018, Sunguk Lee
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+*/
+
+#ifndef _VITAERROR_H_
+#define _VITAERROR_H_
+
+int __vita_sce_errno_to_errno(int sce_errno);
+
+#endif // _VITAERROR_H_
+
+

--- a/newlib/libc/sys/vita/vitaerror.h
+++ b/newlib/libc/sys/vita/vitaerror.h
@@ -1,5 +1,6 @@
 /*
 
+Copyright (C) 2017, David "Davee" Morgan
 Copyright (C) 2018, Sunguk Lee
 
 Permission is hereby granted, free of charge, to any person obtaining a


### PR DESCRIPTION
original code cannot use
```
if (recv(sock, buf, len, flag) < 0 && errno != EAGAIN) {
}
```
`sceNet*` return SCE specific error code instead POSIX codes, and newlib just use last two bytes
```
err & SCE_ERRNO_MASK
```
patch just remap whole network errors to POSIX codes.

Resolve #20