### PR TITLE
Make localtime and localtime_r aware of system timezone

### DIFF
--- a/newlib/libc/sys/vita/Makefile.am
+++ b/newlib/libc/sys/vita/Makefile.am
@@ -11,7 +11,7 @@ noinst_LIBRARIES = lib.a
 SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o netdb.o error.o
 DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
 
-lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c error.c dirent.c
+lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c error.c dirent.c lcltime_r.c
 lib_a_LIBADD = ${SOCKET_OBJS} ${DIRENT_OBJS}
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)

--- a/newlib/libc/sys/vita/Makefile.in
+++ b/newlib/libc/sys/vita/Makefile.in
@@ -73,7 +73,8 @@ am_lib_a_OBJECTS = lib_a-syscalls.$(OBJEXT) lib_a-sbrk.$(OBJEXT) \
 	lib_a-threading.$(OBJEXT) lib_a-mlock.$(OBJEXT) \
 	lib_a-io.$(OBJEXT) lib_a-socket.$(OBJEXT) lib_a-dup.$(OBJEXT) \
 	lib_a-select.$(OBJEXT) lib_a-netdb.$(OBJEXT) \
-	lib_a-error.$(OBJEXT) lib_a-dirent.$(OBJEXT)
+	lib_a-error.$(OBJEXT) lib_a-dirent.$(OBJEXT) \
+	lib_a-lcltime_r.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
@@ -200,7 +201,7 @@ AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
 SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o netdb.o error.o
 DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
-lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c error.c dirent.c
+lib_a_SOURCES = syscalls.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c netdb.c error.c dirent.c lcltime_r.c
 lib_a_LIBADD = ${SOCKET_OBJS} ${DIRENT_OBJS}
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
@@ -329,6 +330,12 @@ lib_a-dirent.o: dirent.c
 
 lib_a-dirent.obj: dirent.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-dirent.obj `if test -f 'dirent.c'; then $(CYGPATH_W) 'dirent.c'; else $(CYGPATH_W) '$(srcdir)/dirent.c'; fi`
+
+lib_a-lcltime_r.o: lcltime_r.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-lcltime_r.o `test -f 'lcltime_r.c' || echo '$(srcdir)/'`lcltime_r.c
+
+lib_a-lcltime_r.obj: lcltime_r.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-lcltime_r.obj `if test -f 'lcltime_r.c'; then $(CYGPATH_W) 'lcltime_r.c'; else $(CYGPATH_W) '$(srcdir)/lcltime_r.c'; fi`
 
 ID: $(HEADERS) $(SOURCES) $(LISP) $(TAGS_FILES)
 	list='$(SOURCES) $(HEADERS) $(LISP) $(TAGS_FILES)'; \

--- a/newlib/libc/sys/vita/lcltime_r.c
+++ b/newlib/libc/sys/vita/lcltime_r.c
@@ -30,7 +30,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include "vitaerror.h"
 
-#define TRY(x) {rid=x; if (rid < 0) {errno = __vita_sce_errno_to_errno(rid); return NULL;}}
+#define TRY(x) {rid=x; if (rid < 0) {errno = rid; return NULL;}}
 
 
 struct tm *localtime_r(const time_t *timep, struct tm *result)

--- a/newlib/libc/sys/vita/lcltime_r.c
+++ b/newlib/libc/sys/vita/lcltime_r.c
@@ -35,17 +35,16 @@ DEALINGS IN THE SOFTWARE.
 
 struct tm *localtime_r(const time_t *timep, struct tm *result)
 {
-    SceDateTime dt;
-    SceRtcTick tick;
-    time_t localtime;
-    int rid;
+	SceDateTime dt;
+	SceRtcTick tick;
+	time_t localtime;
+	int rid;
 
-    TRY(sceRtcConvertTime_tToDateTime(*timep, &dt));
-    TRY(sceRtcConvertDateTimeToTick(&dt, &tick));
-    TRY(sceRtcConvertUtcToLocalTime(&tick, &tick));
-    TRY(sceRtcConvertTickToDateTime(&tick, &dt));
-    TRY(sceRtcConvertDateTimeToTime_t(&dt, &localtime));
+	TRY(sceRtcConvertTime_tToDateTime(*timep, &dt));
+	TRY(sceRtcConvertDateTimeToTick(&dt, &tick));
+	TRY(sceRtcConvertUtcToLocalTime(&tick, &tick));
+	TRY(sceRtcConvertTickToDateTime(&tick, &dt));
+	TRY(sceRtcConvertDateTimeToTime_t(&dt, &localtime));
 
-    return gmtime_r(&localtime, result);
+	return gmtime_r(&localtime, result);
 }
-

--- a/newlib/libc/sys/vita/lcltime_r.c
+++ b/newlib/libc/sys/vita/lcltime_r.c
@@ -1,0 +1,51 @@
+/*
+
+Copyright (C) 2019, Martin Larralde
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <errno.h>
+#include <sys/time.h>
+#include <sys/types.h>
+
+#include <psp2/rtc.h>
+
+#include "vitaerror.h"
+
+#define TRY(x) {rid=x; if (rid < 0) {errno = __vita_sce_errno_to_errno(rid); return NULL;}}
+
+
+struct tm *localtime_r(const time_t *timep, struct tm *result)
+{
+    SceDateTime dt;
+    SceRtcTick tick;
+    time_t localtime;
+    int rid;
+
+    TRY(sceRtcConvertTime_tToDateTime(*timep, &dt));
+    TRY(sceRtcConvertDateTimeToTick(&dt, &tick));
+    TRY(sceRtcConvertUtcToLocalTime(&tick, &tick));
+    TRY(sceRtcConvertTickToDateTime(&tick, &dt));
+    TRY(sceRtcConvertDateTimeToTime_t(&dt, &localtime));
+
+    return gmtime_r(&localtime, result);
+}
+


### PR DESCRIPTION
Hi everyone !

Just a quick PR to make `localtime_r` (and subsequently `localtime`) aware of the user-specified timezone. Currently, `localtime` and `gmtime` will always return the same value (found after bissecting libretro/RetroArch#7632).

I hope it's the right way to do things, I've been working with the SDK a bit but this is my first time messing with `newlib`'s code.