### PR TITLE
Force minimum backlog of 1 in listen(2)

### DIFF
--- a/newlib/libc/sys/vita/socket.c
+++ b/newlib/libc/sys/vita/socket.c
@@ -208,6 +208,11 @@ int	listen(int s, int backlog)
 		return -1;
 	}
 
+	// Vita's Berkeley sockets implementation rejects a backlog of 0.
+	// However, most other OSes allow this, so force it to 1 for compat.
+	if (backlog < 1)
+		backlog = 1;
+
 	int res = sceNetListen(fdmap->sce_uid, backlog);
 
 	__vita_fd_drop(fdmap);


### PR DESCRIPTION
Most OSes allow `listen` to take a backlog argument of 0, which the spec says should be treated as an implementation-defined minimum. `sceIoListen` rejects everything less than 1, so let's define the minimum as 1 in our implementation.