### PR TITLE
Re-enable fileno

### DIFF
--- a/newlib/libc/include/stdio.h
+++ b/newlib/libc/include/stdio.h
@@ -693,7 +693,7 @@ _ELIDABLE_INLINE int __sputc_r(struct _reent *_ptr, int _c, FILE *_p) {
 #endif /* __BSD_VISIBLE */
 #endif /* _REENT_SMALL */
 
-#if 0 /*ndef __STRICT_ANSI__ - FIXME: must initialize stdio first, use fn */
+#ifndef __STRICT_ANSI__
 #define	fileno(p)	__sfileno(p)
 #endif
 

--- a/newlib/libc/stdio/fileno.c
+++ b/newlib/libc/stdio/fileno.c
@@ -72,6 +72,8 @@ Supporting OS subroutines required: none.
 #include <errno.h>
 #include "local.h"
 
+#undef fileno
+
 int
 _DEFUN(fileno, (f),
        FILE * f)


### PR DESCRIPTION
It seems `fileno` has been disabled 21 years ago with the comment `FIXME: must initialize stdio first, use fn`. I'm not sure what `fn` refers to here.

This PR just re-enables this function if `__STRICT_ANSI__` has not been defined.