### PR TITLE
Remove duplicate `char **environ` definition

### DIFF
--- a/newlib/libc/sys/vita/syscalls.c
+++ b/newlib/libc/sys/vita/syscalls.c
@@ -86,9 +86,6 @@ _close_r(struct _reent *reent, int fd)
 	return 0;
 }
 
-char *__env[1] = { 0 };
-char **environ = __env;
-
 int
 _execve_r(struct _reent *reent, const char *name, char * const *argv,
 		char * const *env)


### PR DESCRIPTION
In GCC, compiling anything that utilizes the global `environ` variable results in a duplicate definition error by the Linker. The only way to fix it was to use the `-Wl,--allow-multiple-definition` linker flag. This is due to environ already being defined in `newlib/libc/stdlib/environ.c`.

Removing the definition in `syscalls.c` should fix the linker errors without the need to use the flag.