### PR TITLE
Add fsync/chmod/realpath/chdir/getcwd/fdopendir/etc implementations 

### DIFF
--- a/newlib/libc/sys/vita/access.c
+++ b/newlib/libc/sys/vita/access.c
@@ -17,17 +17,16 @@
 
 int access(const char *fn, int flags)
 {
-  struct stat s;
-  if (stat(fn, &s))
-    return -1;
-  if (s.st_mode & S_IFDIR)
-    return 0;
-  if (flags & W_OK)
-  {
-    if (s.st_mode & S_IWRITE)
-      return 0;
-    return -1;
-  }
-  return 0;
+	struct stat s;
+	if (stat(fn, &s))
+		return -1;
+	if (s.st_mode & S_IFDIR)
+		return 0;
+	if (flags & W_OK)
+	{
+		if (s.st_mode & S_IWRITE)
+			return 0;
+		return -1;
+	}
+	return 0;
 }
-	

--- a/newlib/libc/sys/vita/clock.c
+++ b/newlib/libc/sys/vita/clock.c
@@ -36,121 +36,125 @@ DEALINGS IN THE SOFTWARE.
 
 clock_t clock()
 {
-  struct tms tim_s;
-  clock_t res;
+	struct tms tim_s;
+	clock_t res;
 
-  if ((res = (clock_t) _times_r (_REENT, &tim_s)) != (clock_t) -1)
-    res = (clock_t) (tim_s.tms_utime + tim_s.tms_stime +
-                     tim_s.tms_cutime + tim_s.tms_cstime);
+	if ((res = (clock_t) _times_r (_REENT, &tim_s)) != (clock_t) -1)
+		res = (clock_t) (tim_s.tms_utime + tim_s.tms_stime +
+				tim_s.tms_cutime + tim_s.tms_cstime);
 
-  return res;
+	return res;
 }
 
 int clock_gettime(clockid_t clk_id, struct timespec *tp)
 {
-    time_t seconds;
-    SceDateTime time;
-    uint64_t t;
+	time_t seconds;
+	SceDateTime time;
+	uint64_t t;
 
-    if (!tp) {
-        errno = EFAULT;
-        return -1;
-    }
-    switch(clk_id) {
-        case CLOCK_REALTIME:
-            sceRtcGetCurrentClockLocalTime(&time);
+	if (!tp)
+	{
+		errno = EFAULT;
+		return -1;
+	}
 
-            sceRtcGetTime_t(&time, &seconds);
+	switch(clk_id) {
+		case CLOCK_REALTIME:
+			sceRtcGetCurrentClockLocalTime(&time);
+			sceRtcGetTime_t(&time, &seconds);
 
-            tp->tv_sec = seconds;
-            tp->tv_nsec = time.microsecond * 1000;
-            return 0;
-            break;
-        case CLOCK_MONOTONIC:
-            t = sceKernelGetProcessTimeWide();
-            tp->tv_sec = t / 1000000;
-            tp->tv_nsec = (t % 1000000) * 1000;
-            return 0;
-            break;
-        default:
-            break;
-    }
-    errno = EINVAL;
-    return -1;
+			tp->tv_sec = seconds;
+			tp->tv_nsec = time.microsecond * 1000;
+			return 0;
+			break;
+		case CLOCK_MONOTONIC:
+			t = sceKernelGetProcessTimeWide();
+			tp->tv_sec = t / 1000000;
+			tp->tv_nsec = (t % 1000000) * 1000;
+			return 0;
+			break;
+		default:
+			break;
+	}
+
+	errno = EINVAL;
+	return -1;
 }
 
 int clock_settime(clockid_t clk_id, const struct timespec *tp)
 {
-    if (!tp) {
-        errno = EFAULT;
-        return -1;
-    }
-    errno = EPERM;
-    return -1;
+	if (!tp) {
+		errno = EFAULT;
+		return -1;
+	}
+	errno = EPERM;
+	return -1;
 }
 
 int clock_getres(clockid_t clk_id, struct timespec *res)
 {
-    if (!res) {
-        errno = EFAULT;
-        return -1;
-    }
+	if (!res)
+	{
+		errno = EFAULT;
+		return -1;
+	}
 
-    switch(clk_id) {
-        case CLOCK_REALTIME:
-            res->tv_sec = 0;
-            res->tv_nsec = 1000; // 1 microsecond
-            return 0;
-            break;
-        case CLOCK_MONOTONIC:
-            res->tv_sec = 0;
-            res->tv_nsec = 1000; // 1 microsecond
-            return 0;
-            break;
-        default:
-            break;
-    }
+	switch(clk_id)
+	{
+		case CLOCK_REALTIME:
+			res->tv_sec = 0;
+			res->tv_nsec = 1000; // 1 microsecond
+			return 0;
+			break;
+		case CLOCK_MONOTONIC:
+			res->tv_sec = 0;
+			res->tv_nsec = 1000; // 1 microsecond
+			return 0;
+			break;
+		default:
+			break;
+	}
 
-    errno = EINVAL;
-    return -1;
+	errno = EINVAL;
+	return -1;
 }
 
 int timer_create (clockid_t clock_id,
-        struct sigevent *__restrict evp,
-        timer_t *__restrict timerid)
+	struct sigevent *__restrict evp,
+	timer_t *__restrict timerid)
 {
-    errno = ENOTSUP;
-    return -1;
+	errno = ENOTSUP;
+	return -1;
 }
 
 int timer_delete (timer_t timerid)
 {
-    errno = EINVAL; // because we can't create timers - any timerid would be invalid
-    return -1;
+	errno = EINVAL; // because we can't create timers - any timerid would be invalid
+	return -1;
 }
 
 int timer_settime (timer_t timerid, int flags,
-        const struct itimerspec *__restrict value,
-        struct itimerspec *__restrict ovalue)
+	const struct itimerspec *__restrict value,
+	struct itimerspec *__restrict ovalue)
 {
-    errno = EINVAL;
-    return -1;
+	errno = EINVAL;
+	return -1;
 }
 
 int timer_gettime (timer_t timerid, struct itimerspec *value)
 {
-    errno = EINVAL;
-    return -1;
+	errno = EINVAL;
+	return -1;
 }
 
 int timer_getoverrun (timer_t timerid)
 {
-    errno = EINVAL;
-    return -1;
+	errno = EINVAL;
+	return -1;
 }
 
 int nanosleep (const struct timespec  *rqtp, struct timespec *rmtp)
 {
-    errno = ENOSYS;
-    return -1;
+	errno = ENOSYS;
+	return -1;
 }

--- a/newlib/libc/sys/vita/crt0.c
+++ b/newlib/libc/sys/vita/crt0.c
@@ -8,14 +8,16 @@
 int main(int argc, const char* argv[]);
 void __libc_init_array (void);
 
-void _init_vita_newlib(void) {
+void _init_vita_newlib(void)
+{
 	_init_vita_heap();
 	_init_vita_reent();
 	_init_vita_malloc();
 	_init_vita_io();
 }
 
-void _free_vita_newlib(void) {
+void _free_vita_newlib(void)
+{
 	_free_vita_io();
 	_free_vita_malloc();
 	_free_vita_reent();

--- a/newlib/libc/sys/vita/dirent.c
+++ b/newlib/libc/sys/vita/dirent.c
@@ -24,40 +24,38 @@ DEALINGS IN THE SOFTWARE.
 
 #include <sys/dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <psp2/types.h>
 #include <psp2/io/dirent.h>
 #include <psp2/kernel/threadmgr.h>
-
-#define SCE_ERRNO_MASK 0xFF
-#define MAXNAMLEN	256
+#include "vitadescriptor.h"
+#include "vitaerror.h"
 
 struct DIR_
 {
-	SceUID uid;
+	int fd;
 	struct dirent dir;
-	char dirname[MAXNAMLEN];
 	int index;
 };
 
 int	closedir(DIR *dirp)
 {
-	if (!dirp || dirp->uid < 0)
+	if (!dirp || !dirp->fd)
 	{
 		errno = EBADF;
 		return -1;
 	}
 
-	int res = sceIoDclose(dirp->uid);
-	dirp->uid = -1;
-
+	int res = close(dirp->fd);
 	free(dirp);
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
 		return -1;
 	}
 
@@ -65,31 +63,52 @@ int	closedir(DIR *dirp)
 	return 0;
 }
 
-DIR *opendir(const char *dirname)
+DIR *__opendir_common(int fd)
 {
-	SceUID uid = sceIoDopen(dirname);
-
-	if (uid < 0)
-	{
-		errno = uid & SCE_ERRNO_MASK;
-		return NULL;
-	}
-
 	DIR *dirp = calloc(1, sizeof(DIR));
 
 	if (!dirp)
 	{
-		sceIoDclose(uid);
+		close(fd);
 		errno = ENOMEM;
 		return NULL;
 	}
 
-	dirp->uid = uid;
-	strncpy(dirp->dirname, dirname, sizeof(dirp->dirname)-1 );
+	dirp->fd = fd;
 	dirp->index = 0;
 
 	errno = 0;
 	return dirp;
+}
+
+DIR *opendir(const char *dirname)
+{
+	int fd;
+
+	if ((fd = open(dirname, O_RDONLY | O_DIRECTORY)) == -1)
+		return (NULL);
+	return (__opendir_common(fd));
+}
+
+DIR *fdopendir(int fd)
+{
+	DescriptorTranslation *fdmap = __vita_fd_grab(fd);
+	if (!fdmap)
+	{
+		errno = EBADF;
+		return NULL;
+	}
+
+	if (fdmap->type != VITA_DESCRIPTOR_DIRECTORY)
+	{
+		__vita_fd_drop(fdmap);
+		errno = ENOTDIR;
+		return NULL;
+	}
+
+	__vita_fd_drop(fdmap);
+
+	return (__opendir_common(fd));
 }
 
 struct dirent *readdir(DIR *dirp)
@@ -100,17 +119,26 @@ struct dirent *readdir(DIR *dirp)
 		return NULL;
 	}
 
-	int res = sceIoDread(dirp->uid, (SceIoDirent *)&dirp->dir);
+	DescriptorTranslation *fdmap = __vita_fd_grab(dirp->fd);
+	if (!fdmap)
+	{
+		errno = EBADF;
+		return NULL;
+	}
+
+	int res = sceIoDread(fdmap->sce_uid, (SceIoDirent *)&dirp->dir);
+
+	__vita_fd_drop(fdmap);
 
 	if (res < 0)
 	{
-		errno = res & SCE_ERRNO_MASK;
+		errno = __vita_sce_errno_to_errno(res, ERROR_GENERIC);
 		return NULL;
 	}
 
 	if (res == 0)
 	{
-		errno = 0;
+		// end-of-listing shouldn't change errno
 		return NULL;
 	}
 
@@ -127,17 +155,26 @@ void rewinddir(DIR *dirp)
 		return;
 	}
 
-	SceUID dirfd = sceIoDopen(dirp->dirname);
-
-	if (dirfd < 0)
+	DescriptorTranslation *fdmap = __vita_fd_grab(dirp->fd);
+	if (!fdmap)
 	{
-		errno = dirfd & SCE_ERRNO_MASK;
+		errno = EBADF;
 		return;
 	}
 
-	sceIoDclose(dirp->uid);
+	SceUID dirfd = sceIoDopen(fdmap->filename); // filename contains full path, so it's okay to use in sce funcs
 
-	dirp->uid = dirfd;
+	if (dirfd < 0)
+	{
+		__vita_fd_drop(fdmap);
+		errno = __vita_sce_errno_to_errno(dirfd, ERROR_GENERIC);
+		return;
+	}
+
+	sceIoDclose(fdmap->sce_uid);
+	fdmap->sce_uid = dirfd;
+	__vita_fd_drop(fdmap);
+
 	dirp->index = 0;
 	errno = 0;
 }
@@ -166,7 +203,6 @@ void seekdir(DIR *dirp, long int index)
 			return;
 		}
 	}
-
 }
 
 long int telldir(DIR *dirp)
@@ -178,4 +214,81 @@ long int telldir(DIR *dirp)
 	}
 
 	return dirp->index;
+}
+
+int dirfd(DIR *dirp)
+{
+	if (!dirp)
+	{
+		errno = EINVAL;
+		return -1;
+	}
+
+	return dirp->fd;
+}
+
+int readdir_r(DIR *restrict dirp, struct dirent *restrict entry, struct dirent **restrict result)
+{
+	*result = NULL;
+	errno = 0;
+	struct dirent *next = readdir(dirp);
+	if(errno != 0 && next == NULL)
+	{
+		return errno;
+	}
+	if(next)
+	{
+		memcpy(entry, next, sizeof(struct dirent));
+		*result = entry;
+	}
+	return 0;
+}
+
+int
+alphasort(const struct dirent **d1, const struct dirent **d2)
+{
+	return (strcoll((*d1)->d_name, (*d2)->d_name));
+}
+
+// modified from musl
+int scandir(const char *path, struct dirent ***res,
+	int (*sel)(const struct dirent *),
+	int (*cmp)(const struct dirent **, const struct dirent **))
+{
+	DIR *d = opendir(path);
+	struct dirent *de, **names=0, **tmp;
+	size_t cnt=0, len=0;
+	int old_errno = errno;
+
+	if (!d) return -1;
+
+	while ((errno=0), (de = readdir(d)))
+	{
+		if (sel && !sel(de)) continue;
+		if (cnt >= len)
+		{
+			len = 2*len+1;
+			if (len > SIZE_MAX/sizeof *names) break;
+			tmp = realloc(names, len * sizeof *names);
+			if (!tmp) break;
+			names = tmp;
+		}
+		names[cnt] = malloc(sizeof(struct dirent));
+		if (!names[cnt]) break;
+		memcpy(names[cnt++], de, sizeof(struct dirent));
+	}
+
+	closedir(d);
+
+	if (errno)
+	{
+		if (names) while (cnt-- > 0) free(names[cnt]);
+		free(names);
+		return -1;
+	}
+	errno = old_errno;
+
+	if (cmp) qsort(names, cnt, sizeof *names, (int (*)(const void *, const void *))cmp);
+	*res = names;
+	return cnt;
 }

--- a/newlib/libc/sys/vita/dirent.c
+++ b/newlib/libc/sys/vita/dirent.c
@@ -69,7 +69,6 @@ DIR *__opendir_common(int fd)
 
 	if (!dirp)
 	{
-		close(fd);
 		errno = ENOMEM;
 		return NULL;
 	}
@@ -87,7 +86,12 @@ DIR *opendir(const char *dirname)
 
 	if ((fd = open(dirname, O_RDONLY | O_DIRECTORY)) == -1)
 		return (NULL);
-	return (__opendir_common(fd));
+	DIR *ret = __opendir_common(fd);
+	if (!ret)
+	{
+		close(fd);
+	}
+	return ret;
 }
 
 DIR *fdopendir(int fd)

--- a/newlib/libc/sys/vita/dup.c
+++ b/newlib/libc/sys/vita/dup.c
@@ -27,14 +27,14 @@ DEALINGS IN THE SOFTWARE.
 
 int dup(int oldfd)
 {
-    int fd = __vita_duplicate_descriptor(oldfd);
+	int fd = __vita_duplicate_descriptor(oldfd);
 
-    if (fd < 0)
-    {
-        errno = EBADF;
-        return -1;
-    }
+	if (fd < 0)
+	{
+		errno = EBADF;
+		return -1;
+	}
 
-    errno = 0;
-    return fd;
+	errno = 0;
+	return fd;
 }

--- a/newlib/libc/sys/vita/error.c
+++ b/newlib/libc/sys/vita/error.c
@@ -27,8 +27,23 @@ DEALINGS IN THE SOFTWARE.
 #include <psp2/net/net.h>
 
 #include "vitaerror.h"
+#include "vitadescriptor.h"
 
-int __vita_sce_errno_to_errno(int sce_errno)
+int __vita_sce_errno_to_errno(int sce_errno, int type)
+{
+	if (type == ERROR_SOCKET)
+	{
+		return __vita_scenet_errno_to_errno(sce_errno);
+	}
+	return sce_errno & SCE_ERRNO_MASK;
+}
+
+int __vita_make_sce_errno(int posix_errno)
+{
+	return SCE_ERRNO_NONE | posix_errno;
+}
+
+int __vita_scenet_errno_to_errno(int sce_errno)
 {
 	switch (sce_errno)
 	{

--- a/newlib/libc/sys/vita/fs.c
+++ b/newlib/libc/sys/vita/fs.c
@@ -27,13 +27,19 @@ DEALINGS IN THE SOFTWARE.
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/dirent.h>
 #include <sys/stat.h>
+#include <sys/syslimits.h>
+#include <string.h>
 
 #include <psp2/types.h>
 #include <psp2/io/stat.h>
+#include "vitaerror.h"
+#include "vitadescriptor.h"
+#include "vitafs.h"
 
-#define SCE_ERRNO_MASK 0xFF
+static char __cwd[PATH_MAX] = {0};
 
 int mkdir(const char *pathname, mode_t mode)
 {
@@ -43,10 +49,480 @@ int mkdir(const char *pathname, mode_t mode)
 int rmdir(const char *pathname)
 {
 	int ret;
-	if ((ret = sceIoRmdir(pathname)) < 0) {
-		errno = ret & SCE_ERRNO_MASK;
+	char* full_path = __realpath(pathname);
+	if(!full_path)
+	{
+		errno = errno; // set by realpath
 		return -1;
 	}
+
+	if ((ret = sceIoRmdir(full_path)) < 0)
+	{
+		free(full_path);
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return -1;
+	}
+	free(full_path);
 	errno = 0;
+	return 0;
+}
+
+int lstat(const char *path, struct stat *buf)
+{
+	return _stat_r(_REENT, path, buf);
+}
+
+int chmod(const char *pathname, mode_t mode)
+{
+	struct SceIoStat stat = {0};
+	char* full_path = __realpath(pathname);
+	if(!full_path)
+	{
+		errno = errno; // set by realpath
+		return -1;
+	}
+	int ret = sceIoGetstat(full_path, &stat);
+	if (ret < 0)
+	{
+		free(full_path);
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return -1;
+	}
+
+	stat.st_mode = mode;
+	ret = sceIoChstat(full_path, &stat, SCE_CST_MODE);
+	if (ret < 0)
+	{
+		free(full_path);
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return -1;
+	}
+	free(full_path);
+	return 0;
+}
+
+int fchmod(int fd, mode_t mode)
+{
+	struct SceIoStat stat = {0};
+	int ret = 0;
+
+	DescriptorTranslation *fdmap = __vita_fd_grab(fd);
+
+	if (!fdmap)
+	{
+		errno = EBADF;
+		return -1;
+	}
+
+	switch (fdmap->type)
+	{
+		case VITA_DESCRIPTOR_TTY:
+		case VITA_DESCRIPTOR_FILE:
+		case VITA_DESCRIPTOR_DIRECTORY:
+			ret = sceIoGetstatByFd(fdmap->sce_uid, &stat);
+			break;
+		case VITA_DESCRIPTOR_SOCKET:
+			ret = __vita_make_sce_errno(EBADF);
+			break;
+	}
+
+	if (ret < 0)
+	{
+		__vita_fd_drop(fdmap);
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return -1;
+	}
+
+	stat.st_mode = mode;
+	ret = sceIoChstatByFd(fdmap->sce_uid, &stat, SCE_CST_MODE);
+
+	__vita_fd_drop(fdmap);
+
+	if (ret < 0)
+	{
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return -1;
+	}
+
+	return 0;
+}
+
+int fsync(int fd)
+{
+	int ret = 0;
+
+	DescriptorTranslation *fdmap = __vita_fd_grab(fd);
+
+	if (!fdmap)
+	{
+		errno = EBADF;
+		return -1;
+	}
+
+	switch (fdmap->type)
+	{
+		case VITA_DESCRIPTOR_DIRECTORY:
+		case VITA_DESCRIPTOR_FILE:
+			ret = sceIoSyncByFd(fdmap->sce_uid, 0);
+			break;
+		case VITA_DESCRIPTOR_TTY:
+		case VITA_DESCRIPTOR_SOCKET:
+			ret = __vita_make_sce_errno(EINVAL);
+			break;
+	}
+
+	__vita_fd_drop(fdmap);
+
+	if (ret < 0)
+	{
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return -1;
+	}
+	return 0;
+}
+
+int fdatasync(int fd)
+{
+	return fsync(fd);
+}
+
+// cwd impl
+
+// get end of drive position from full path
+static int __get_drive(const char *path)
+{
+	int i;
+	for(i=0; path[i]; i++) {
+		if(! ((path[i] >= 'a' && path[i] <= 'z') || (path[i] >= '0' && path[i] <= '9') ))
+			break;
+	}
+
+	if(path[i] == ':') return i+1;
+	return 0;
+}
+
+static void __init_cwd()
+{
+	if (strlen(__cwd) == 0)
+	{
+		// init cwd
+		strcpy(__cwd, "app0:");
+	}
+}
+
+char *getcwd(char *buf, size_t size)
+{
+	__init_cwd();
+
+	if (buf != NULL && size == 0)
+	{
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if(buf && strlen(__cwd) >= size) {
+		errno = ERANGE;
+		return NULL;
+	}
+
+	// latest POSIX says it's implementation-defined
+	// musl, glibc and bionic allocs buffer if it's null.
+	// so we'll do the same
+	if (buf == NULL)
+	{
+		buf = (char*)calloc(PATH_MAX, sizeof(char));
+		if (buf == NULL)
+		{
+			errno = ENOMEM;
+			return NULL;
+		}
+	}
+
+	strcpy(buf, __cwd);
+	return buf;
+}
+
+// modified from bionic
+char *__resolve_path(const char *path, char resolved[PATH_MAX])
+{
+	char *p, *q, *s;
+	size_t left_len, resolved_len;
+	char left[PATH_MAX], next_token[PATH_MAX];
+	if (path[0] == '/')
+	{
+		resolved[0] = '/';
+		resolved[1] = '\0';
+		if (path[1] == '\0')
+			return (resolved);
+		resolved_len = 1;
+		left_len = strlcpy(left, path + 1, sizeof(left));
+	}
+	else
+	{
+		resolved_len = 0;
+		left_len = strlcpy(left, path, sizeof(left));
+	}
+	if (left_len >= sizeof(left) || resolved_len >= PATH_MAX)
+	{
+		errno = ENAMETOOLONG;
+		return (NULL);
+	}
+	/*
+	 * Iterate over path components in `left'.
+	 */
+	while (left_len != 0)
+	{
+		/*
+		 * Extract the next path component and adjust `left'
+		 * and its length.
+		 */
+		p = strchr(left, '/');
+		s = p ? p : left + left_len;
+		if (s - left >= sizeof(next_token))
+		{
+			errno = ENAMETOOLONG;
+			return (NULL);
+		}
+		memcpy(next_token, left, s - left);
+		next_token[s - left] = '\0';
+		left_len -= s - left;
+		if (p != NULL)
+			memmove(left, s + 1, left_len + 1);
+		if (resolved[resolved_len - 1] != '/')
+		{
+			if (resolved_len + 1 >= PATH_MAX)
+			{
+				errno = ENAMETOOLONG;
+				return (NULL);
+			}
+			resolved[resolved_len++] = '/';
+			resolved[resolved_len] = '\0';
+		}
+		if (next_token[0] == '\0')
+			continue;
+		else if (strcmp(next_token, ".") == 0)
+			continue;
+		else if (strcmp(next_token, "..") == 0)
+		{
+			/*
+			 * Strip the last path component except when we have
+			 * single "/"
+			 */
+			if (resolved_len > 1) {
+				resolved[resolved_len - 1] = '\0';
+				q = strrchr(resolved, '/') + 1;
+				*q = '\0';
+				resolved_len = q - resolved;
+			}
+			continue;
+		}
+		/*
+		 * Append the next path component. 
+		 */
+		resolved_len = strlcat(resolved, next_token, PATH_MAX);
+		if (resolved_len >= PATH_MAX)
+		{
+			errno = ENAMETOOLONG;
+			return (NULL);
+		}
+	}
+	/*
+	 * Remove trailing slash except when the resolved pathname
+	 * is a single "/".
+	 */
+	if (resolved_len > 1 && resolved[resolved_len - 1] == '/')
+		resolved[resolved_len - 1] = '\0';
+	return (resolved);
+}
+
+// internal, without stat check. Used for mkdir/open/etc.
+char *__realpath(const char *path)
+{
+	char resolved[PATH_MAX] = {0};
+	char result[PATH_MAX] = {0};
+	char *resolved_path = NULL;
+
+	// can't have null path
+	if (!path)
+	{
+		errno = EINVAL;
+		return NULL;
+	}
+
+	// empty path would resolve to cwd
+	// POSIX.1-2008 states that ENOENT should be returned if path points to empty string
+	if (strlen(path) == 0)
+	{
+		errno = ENOENT;
+		return NULL;
+	}
+
+	resolved_path = (char*)calloc(PATH_MAX, sizeof(char));
+	if (!resolved_path)
+	{
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	int d = __get_drive(path);
+
+	if (d) // absolute path with drive
+	{
+		__resolve_path(path + d, resolved);
+		if (strlen(resolved) + d < PATH_MAX)
+		{
+			strncpy(result, path, d);
+			strcat(result, resolved);
+			strcpy(resolved_path, result);
+			return resolved_path;
+		}
+		errno = ENAMETOOLONG;
+		free(resolved_path);
+		return NULL;
+	}
+	else if (path[0] == '/') // absolute path without drive
+	{
+		__init_cwd();
+		__resolve_path(path, resolved);
+		d = __get_drive(__cwd);
+		if (strlen(resolved) + d < PATH_MAX)
+		{
+			strncpy(result, __cwd, d);
+			strcat(result, resolved);
+			strcpy(resolved_path, result);
+			return resolved_path;
+		}
+		errno = ENAMETOOLONG;
+		free(resolved_path);
+		return NULL;
+	}
+	else // relative path
+	{
+		__init_cwd();
+		char full_path[PATH_MAX] = {0};
+		if (strlen(__cwd) + strlen(path) < PATH_MAX)
+		{
+			strcpy(full_path, __cwd);
+			strcat(full_path, "/");
+			strcat(full_path, path);
+			d = __get_drive(full_path);
+
+			__resolve_path(full_path + d, resolved);
+			if (strlen(resolved) + d < PATH_MAX)
+			{
+				strncpy(result, full_path, d);
+				strcat(result, resolved);
+				strcpy(resolved_path, result);
+				return resolved_path;
+			}
+			errno = ENAMETOOLONG;
+			free(resolved_path);
+			return NULL;
+		}
+		errno = ENAMETOOLONG;
+		free(resolved_path);
+		return NULL;
+	}
+}
+
+int __is_dir(const char *path)
+{
+	SceIoStat stat;
+	int ret = sceIoGetstat(path, &stat);
+	if (ret < 0)
+	{
+		return ret;
+	}
+	if (!SCE_S_ISDIR(stat.st_mode))
+	{
+		return __vita_make_sce_errno(ENOTDIR);
+	}
+	return 0;
+}
+
+char *realpath(const char *path, char* resolved_path)
+{
+	char *fullpath = __realpath(path);
+	if (!fullpath)
+	{
+		return NULL; // errno already set
+	}
+
+	SceIoStat stat;
+	int ret = sceIoGetstat(fullpath, &stat);
+	if (ret < 0)
+	{
+		free(fullpath);
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return NULL;
+	}
+
+	if (!resolved_path)
+	{
+		resolved_path = fullpath;
+	}
+	else
+	{
+		strcpy(resolved_path, fullpath);
+		free(fullpath);
+	}
+
+	return resolved_path;
+}
+
+int chdir(const char *path)
+{
+	char *fullpath = NULL;
+
+	if (!path) // different error
+	{
+		errno = EFAULT;
+		return -1;
+	}
+
+	fullpath = __realpath(path);
+	if (!fullpath)
+	{
+		return -1; // errno already set
+	}
+
+	int ret = __is_dir(fullpath);
+	if (ret < 0)
+	{
+		free(fullpath);
+		errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		return -1;
+	}
+
+	strcpy(__cwd, fullpath);
+	free(fullpath);
+	return 0;
+}
+
+int fchdir(int fd)
+{
+	int ret;
+	DescriptorTranslation *fdmap = __vita_fd_grab(fd);
+
+	if (!fdmap)
+	{
+		errno = EBADF;
+		return -1;
+	}
+
+	switch (fdmap->type)
+	{
+		case VITA_DESCRIPTOR_TTY:
+		case VITA_DESCRIPTOR_FILE:
+		case VITA_DESCRIPTOR_SOCKET:
+			__vita_fd_drop(fdmap);
+			errno = ENOTDIR;
+			return -1;
+			break;
+		case VITA_DESCRIPTOR_DIRECTORY:
+			ret = chdir(fdmap->filename);
+			__vita_fd_drop(fdmap);
+			return ret;
+	}
 	return 0;
 }

--- a/newlib/libc/sys/vita/fs.c
+++ b/newlib/libc/sys/vita/fs.c
@@ -52,7 +52,7 @@ int rmdir(const char *pathname)
 	char* full_path = __realpath(pathname);
 	if(!full_path)
 	{
-		errno = errno; // set by realpath
+		// errno is set by __realpath
 		return -1;
 	}
 
@@ -78,7 +78,7 @@ int chmod(const char *pathname, mode_t mode)
 	char* full_path = __realpath(pathname);
 	if(!full_path)
 	{
-		errno = errno; // set by realpath
+		// errno is set by __realpath
 		return -1;
 	}
 	int ret = sceIoGetstat(full_path, &stat);

--- a/newlib/libc/sys/vita/getentropy.c
+++ b/newlib/libc/sys/vita/getentropy.c
@@ -32,34 +32,38 @@ DEALINGS IN THE SOFTWARE.
 
 int getentropy(void *ptr, size_t n)
 {
-    size_t target = n;
-    void* p = ptr;
-    int ret;
+	size_t target = n;
+	void* p = ptr;
+	int ret;
 
-    if (n > MAX_ENTROPY) {
-        errno = EIO;
-        return -1;
-    }
+	if (n > MAX_ENTROPY)
+	{
+		errno = EIO;
+		return -1;
+	}
 
-    while (target > 64) {
-        ret = sceKernelGetRandomNumber(ptr, 64);
-        ptr += 64;
-        target -= 64;
-        if (ret < 0 ) {
-            errno = EIO;
-            return -1;
-        }
-    }
+	while (target > 64)
+	{
+		ret = sceKernelGetRandomNumber(ptr, 64);
+		ptr += 64;
+		target -= 64;
+		if (ret < 0 )
+		{
+			errno = EIO;
+			return -1;
+		}
+	}
 
-    ret = sceKernelGetRandomNumber(ptr, target);
-    if (ret < 0 ) {
-        errno = EIO;
-        return -1;
-    }
-    return 0;
+	ret = sceKernelGetRandomNumber(ptr, target);
+	if (ret < 0 )
+	{
+		errno = EIO;
+		return -1;
+	}
+	
+	return 0;
 }
 
 void _arc4random_getentropy_fail(void)
 {
-
 }

--- a/newlib/libc/sys/vita/getentropy.c
+++ b/newlib/libc/sys/vita/getentropy.c
@@ -28,21 +28,38 @@ DEALINGS IN THE SOFTWARE.
 
 #include <psp2/kernel/rng.h>
 
-#define MAX_ENTROPY 64
+#define MAX_ENTROPY 256
 
 int getentropy(void *ptr, size_t n)
-{ 
-   if (n > MAX_ENTROPY) {
-		errno = -EIO;
-		return -1;
-	}
+{
+    size_t target = n;
+    void* p = ptr;
+    int ret;
 
-   int ret = sceKernelGetRandomNumber(ptr, n);
-   
-   return (ret == 0) ? 0 : -1;
+    if (n > MAX_ENTROPY) {
+        errno = EIO;
+        return -1;
+    }
+
+    while (target > 64) {
+        ret = sceKernelGetRandomNumber(ptr, 64);
+        ptr += 64;
+        target -= 64;
+        if (ret < 0 ) {
+            errno = EIO;
+            return -1;
+        }
+    }
+
+    ret = sceKernelGetRandomNumber(ptr, target);
+    if (ret < 0 ) {
+        errno = EIO;
+        return -1;
+    }
+    return 0;
 }
 
 void _arc4random_getentropy_fail(void)
-{ 
+{
 
 }

--- a/newlib/libc/sys/vita/lcltime_r.c
+++ b/newlib/libc/sys/vita/lcltime_r.c
@@ -30,7 +30,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include "vitaerror.h"
 
-#define TRY(x) {rid=x; if (rid < 0) {errno = rid; return NULL;}}
+#define TRY(x) {rid=x; if (rid < 0) {errno = __vita_sce_errno_to_errno(rid, ERROR_GENERIC); return NULL;}}
 
 
 struct tm *localtime_r(const time_t *timep, struct tm *result)

--- a/newlib/libc/sys/vita/mlock.c
+++ b/newlib/libc/sys/vita/mlock.c
@@ -3,18 +3,22 @@
 
 static SceKernelLwMutexWork _newlib_malloc_mutex;
 
-void __malloc_lock(struct _reent *r) {
+void __malloc_lock(struct _reent *r)
+{
 	sceKernelLockLwMutex(&_newlib_malloc_mutex, 1, 0);
 }
 
-void __malloc_unlock(struct _reent *r) {
+void __malloc_unlock(struct _reent *r)
+{
 	sceKernelUnlockLwMutex(&_newlib_malloc_mutex, 1);
 }
 
-void _init_vita_malloc(void) {
+void _init_vita_malloc(void)
+{
 	sceKernelCreateLwMutex(&_newlib_malloc_mutex, "malloc mutex", 2, 0, 0);
 }
 
-void _free_vita_malloc(void) {
+void _free_vita_malloc(void)
+{
 	sceKernelDeleteLwMutex(&_newlib_malloc_mutex);
 }

--- a/newlib/libc/sys/vita/net/freeaddrinfo.c
+++ b/newlib/libc/sys/vita/net/freeaddrinfo.c
@@ -43,10 +43,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void freeaddrinfo(struct addrinfo *res)
 {
-    while (res != NULL) {
-      struct addrinfo *p = res;
-      res = res->ai_next;
-      free(p->ai_canonname);
-      free(p);
-    }
+	while (res != NULL)
+	{
+		struct addrinfo *p = res;
+		res = res->ai_next;
+		free(p->ai_canonname);
+		free(p);
+	}
 }

--- a/newlib/libc/sys/vita/net/getaddrinfo.c
+++ b/newlib/libc/sys/vita/net/getaddrinfo.c
@@ -69,7 +69,8 @@
 static struct addrinfo *malloc_ai(int port, u_long addr, int socktype, int proto)
 {
 	struct addrinfo *ai = (struct addrinfo *)malloc(sizeof(struct addrinfo) + sizeof(struct sockaddr_in));
-	if (ai) {
+	if (ai)
+	{
 		memset(ai, 0, sizeof(struct addrinfo) + sizeof(struct sockaddr_in));
 		ai->ai_addr = (struct sockaddr *)(ai + 1);
 		/* XXX -- ssh doesn't use sa_len */
@@ -99,24 +100,27 @@ int getaddrinfo(const char *node, const char *service, const struct addrinfo *hi
 	socktype = (hints && hints->ai_socktype) ? hints->ai_socktype : SOCK_STREAM;
 	if (hints && hints->ai_protocol)
 		proto = hints->ai_protocol;
-	else {
-		switch (socktype) {
-		case SOCK_DGRAM:
-			proto = IPPROTO_UDP;
-			break;
-		case SOCK_STREAM:
-			proto = IPPROTO_TCP;
-			break;
-		default:
-			proto = 0;
-			break;
+	else
+	{
+		switch (socktype)
+		{
+			case SOCK_DGRAM:
+				proto = IPPROTO_UDP;
+				break;
+			case SOCK_STREAM:
+				proto = IPPROTO_TCP;
+				break;
+			default:
+				proto = 0;
+				break;
 		}
 	}
 
 	if (service) {
 		if (isdigit((int)*service))
 			port = htons(atoi(service));
-		else {
+		else
+		{
 			struct servent *se;
 			char *pe_proto;
 
@@ -156,9 +160,12 @@ int getaddrinfo(const char *node, const char *service, const struct addrinfo *hi
 	}
 	if (hints && hints->ai_flags & AI_NUMERICHOST)
 		return EAI_NODATA;
-	if ((hp = gethostbyname(node)) && hp->h_name && hp->h_name[0] && hp->h_addr_list[0]) {
-		for (i = 0; hp->h_addr_list[i]; i++) {
-			if ((cur = malloc_ai(port, ((struct in_addr *)hp->h_addr_list[i])->s_addr, socktype, proto)) == NULL) {
+	if ((hp = gethostbyname(node)) && hp->h_name && hp->h_name[0] && hp->h_addr_list[0])
+	{
+		for (i = 0; hp->h_addr_list[i]; i++)
+		{
+			if ((cur = malloc_ai(port, ((struct in_addr *)hp->h_addr_list[i])->s_addr, socktype, proto)) == NULL)
+			{
 				if (*res)
 					freeaddrinfo(*res);
 				return EAI_MEMORY;
@@ -169,9 +176,11 @@ int getaddrinfo(const char *node, const char *service, const struct addrinfo *hi
 				*res = cur;
 			prev = cur;
 		}
-		if (hints && hints->ai_flags & AI_CANONNAME && *res) {
+		if (hints && hints->ai_flags & AI_CANONNAME && *res)
+		{
 			/* NOT sasl_strdup for compatibility */
-			if (((*res)->ai_canonname = strdup(hp->h_name)) == NULL) {
+			if (((*res)->ai_canonname = strdup(hp->h_name)) == NULL)
+			{
 				freeaddrinfo(*res);
 				return EAI_MEMORY;
 			}

--- a/newlib/libc/sys/vita/net/gethostbyaddr.c
+++ b/newlib/libc/sys/vita/net/gethostbyaddr.c
@@ -4,42 +4,45 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <psp2/net/net.h>
+#include "../vitaerror.h"
 
-#define SCE_ERRNO_MASK 0xFF
+struct hostent *gethostbyaddr(const void *addr, socklen_t len, int type)
+{
+	static struct hostent ent;
+	char name[NI_MAXHOST];
+	static char sname[NI_MAXHOST] = "";
+	static char *addrlist[2] = { NULL, NULL };
 
-struct hostent *gethostbyaddr(const void *addr, socklen_t len, int type) {
-    static struct hostent ent;
-    char name[NI_MAXHOST];
-    static char sname[NI_MAXHOST] = "";
-    static char *addrlist[2] = { NULL, NULL };
+	if (type != SCE_NET_AF_INET)
+	{
+		errno = SCE_NET_ERROR_RESOLVER_ENOSUPPORT;
+		return NULL;
+	}
 
-    if (type != SCE_NET_AF_INET) {
-        errno = SCE_NET_ERROR_RESOLVER_ENOSUPPORT;
-        return NULL;
-    }
+	int rid = sceNetResolverCreate("resolver", NULL, 0);
+	if (rid < 0)
+	{
+		errno = __vita_scenet_errno_to_errno(rid);
+		return NULL;
+	}
 
-    int rid = sceNetResolverCreate("resolver", NULL, 0);
-    if (rid < 0) {
-        errno = rid & SCE_ERRNO_MASK;
-        return NULL;
-    }
+	int err = sceNetResolverStartAton(rid, addr, name, sizeof(name), 0, 0, 0);
+	sceNetResolverDestroy(rid);
+	if (err < 0)
+	{
+		errno = __vita_scenet_errno_to_errno(err);
+		return NULL;
+	}
 
-    int err = sceNetResolverStartAton(rid, addr, name, sizeof(name), 0, 0, 0);
-    sceNetResolverDestroy(rid);
-    if (err < 0) {
-        errno = err & SCE_ERRNO_MASK;
-        return NULL;
-    }
+	strncpy(sname, name, NI_MAXHOST - 1);
+	addrlist[0] = (char *) addr;
 
-    strncpy(sname, name, NI_MAXHOST - 1);
-    addrlist[0] = (char *) addr;
+	ent.h_name = sname;
+	ent.h_aliases = 0;
+	ent.h_addrtype = type;
+	ent.h_length = sizeof(struct SceNetInAddr);
+	ent.h_addr_list = addrlist;
+	ent.h_addr = addrlist[0];
 
-    ent.h_name = sname;
-    ent.h_aliases = 0;
-    ent.h_addrtype = type;
-    ent.h_length = sizeof(struct SceNetInAddr);
-    ent.h_addr_list = addrlist;
-    ent.h_addr = addrlist[0];
-
-    return &ent;
+	return &ent;
 }

--- a/newlib/libc/sys/vita/net/gethostbyname.c
+++ b/newlib/libc/sys/vita/net/gethostbyname.c
@@ -3,26 +3,29 @@
 #include <netdb.h>
 #include <errno.h>
 #include <psp2/net/net.h>
+#include "../vitaerror.h"
 
-#define SCE_ERRNO_MASK 0xFF
 #define MAX_NAME 512
 
-struct hostent *gethostbyname(const char *name) {
+struct hostent *gethostbyname(const char *name)
+{
 	static struct hostent ent;
 	static char sname[MAX_NAME] = "";
 	static struct SceNetInAddr saddr = {0};
 	static char *addrlist[2] = { (char *) &saddr, NULL };
 
 	int rid = sceNetResolverCreate("resolver", NULL, 0);
-	if (rid < 0) {
-		errno = rid & SCE_ERRNO_MASK;
+	if (rid < 0)
+	{
+		errno = __vita_scenet_errno_to_errno(rid);
 		return NULL;
 	}
 
 	int err = sceNetResolverStartNtoa(rid, name, &saddr, 0, 0, 0);
 	sceNetResolverDestroy(rid);
-	if (err < 0) {
-		errno = err & SCE_ERRNO_MASK;
+	if (err < 0)
+	{
+		errno = __vita_scenet_errno_to_errno(err);
 		return NULL;
 	}
 

--- a/newlib/libc/sys/vita/pread.c
+++ b/newlib/libc/sys/vita/pread.c
@@ -7,8 +7,6 @@
 #include "vitadescriptor.h"
 #include "vitaerror.h"
 
-#define SCE_ERRNO_MASK 0xFF
-
 ssize_t pread (int __fd, void *__buf, size_t __nbytes, off_t __offset)
 {
 	int ret;
@@ -25,7 +23,7 @@ ssize_t pread (int __fd, void *__buf, size_t __nbytes, off_t __offset)
 
 	if (ret < 0) {
 		if (ret != -1 )
-			errno = ret & SCE_ERRNO_MASK;
+			errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 
@@ -49,7 +47,7 @@ ssize_t pwrite (int __fd, const void *__buf, size_t __nbytes, off_t __offset)
 
 	if (ret < 0) {
 		if (ret != -1)
-			errno = ret & SCE_ERRNO_MASK;
+			errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 

--- a/newlib/libc/sys/vita/sbrk.c
+++ b/newlib/libc/sys/vita/sbrk.c
@@ -11,10 +11,12 @@ static unsigned _newlib_heap_size;
 static char *_newlib_heap_base, *_newlib_heap_end, *_newlib_heap_cur;
 static SceKernelLwMutexWork _newlib_sbrk_mutex;
 
-void * _sbrk_r(struct _reent *reent, ptrdiff_t incr) {
+void * _sbrk_r(struct _reent *reent, ptrdiff_t incr)
+{
 	if (sceKernelLockLwMutex(&_newlib_sbrk_mutex, 1, 0) < 0)
 		goto fail;
-	if (!_newlib_heap_base || _newlib_heap_cur + incr >= _newlib_heap_end) {
+	if (!_newlib_heap_base || _newlib_heap_cur + incr >= _newlib_heap_end)
+	{
 		sceKernelUnlockLwMutex(&_newlib_sbrk_mutex, 1);
 fail:
 		reent->_errno = ENOMEM;
@@ -28,22 +30,29 @@ fail:
 	return (void*) prev_heap_end;
 }
 
-void _init_vita_heap(void) {
+void _init_vita_heap(void)
+{
 	// Create a mutex to use inside _sbrk_r
-	if (sceKernelCreateLwMutex(&_newlib_sbrk_mutex, "sbrk mutex", 0, 0, 0) < 0) {
+	if (sceKernelCreateLwMutex(&_newlib_sbrk_mutex, "sbrk mutex", 0, 0, 0) < 0)
+	{
 		goto failure;
 	}
-	if (&_newlib_heap_size_user != NULL) {
+	if (&_newlib_heap_size_user != NULL)
+	{
 		_newlib_heap_size = _newlib_heap_size_user;
-	} else {
+	}
+	else
+	{
 		// Create a memblock for the heap memory, 32MB
 		_newlib_heap_size = 32 * 1024 * 1024;
 	}
 	_newlib_heap_memblock = sceKernelAllocMemBlock("Newlib heap", 0x0c20d060, _newlib_heap_size, 0);
-	if (_newlib_heap_memblock < 0) {
+	if (_newlib_heap_memblock < 0)
+	{
 		goto failure;
 	}
-	if (sceKernelGetMemBlockBase(_newlib_heap_memblock, (void**)&_newlib_heap_base) < 0) {
+	if (sceKernelGetMemBlockBase(_newlib_heap_memblock, (void**)&_newlib_heap_base) < 0)
+	{
 		goto failure;
 	}
 	_newlib_heap_end = _newlib_heap_base + _newlib_heap_size;
@@ -56,7 +65,8 @@ failure:
 	_newlib_heap_cur = 0;
 }
 
-void _free_vita_heap(void) {
+void _free_vita_heap(void)
+{
 	// Destroy the sbrk mutex
 	sceKernelDeleteLwMutex(&_newlib_sbrk_mutex);
 

--- a/newlib/libc/sys/vita/sleep.c
+++ b/newlib/libc/sys/vita/sleep.c
@@ -27,5 +27,5 @@ DEALINGS IN THE SOFTWARE.
 
 unsigned int sleep(unsigned int seconds)
 {
-    return sceKernelDelayThread(seconds * 1000 * 1000);
+	return sceKernelDelayThread(seconds * 1000 * 1000);
 }

--- a/newlib/libc/sys/vita/socket.c
+++ b/newlib/libc/sys/vita/socket.c
@@ -54,7 +54,7 @@ int accept(int s, struct sockaddr *addr, socklen_t *addrlen)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -89,7 +89,7 @@ int	bind(int s, const struct sockaddr *addr, socklen_t addrlen)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -114,7 +114,7 @@ int	connect(int s, const struct sockaddr *addr, socklen_t addrlen)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -139,7 +139,7 @@ int	getpeername(int s, struct sockaddr *addr, socklen_t *addrlen)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -164,7 +164,7 @@ int	getsockname(int s, struct sockaddr *addr, socklen_t *addrlen)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -189,7 +189,7 @@ int	getsockopt(int s, int level, int optname, void *optval, socklen_t *optlen)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -219,7 +219,7 @@ int	listen(int s, int backlog)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -244,7 +244,7 @@ ssize_t	recv(int s, void *buf, size_t len, int flags)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -270,7 +270,7 @@ ssize_t	recvfrom(int s, void *buf, size_t len, int flags,
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -295,7 +295,7 @@ ssize_t recvmsg(int s, struct msghdr *msg, int flags)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -320,7 +320,7 @@ ssize_t	send(int s, const void *buf, size_t len, int flags)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -347,7 +347,7 @@ ssize_t	sendto(int s, const void *buf,
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -372,7 +372,7 @@ ssize_t sendmsg(int s, const struct msghdr *msg, int flags)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -411,7 +411,7 @@ int	setsockopt(int s, int level, int optname, const void *optval, socklen_t optl
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -436,7 +436,7 @@ int	shutdown(int s, int how)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 
@@ -451,7 +451,7 @@ int	socket(int domain, int type, int protocol)
 
 	if (res < 0)
 	{
-		errno = __vita_sce_errno_to_errno(res);
+		errno = __vita_scenet_errno_to_errno(res);
 		return -1;
 	}
 

--- a/newlib/libc/sys/vita/syscalls.c
+++ b/newlib/libc/sys/vita/syscalls.c
@@ -289,7 +289,8 @@ _open_r(struct _reent *reent, const char *file, int flags, int mode)
 
 	__vita_fdmap[fd]->sce_uid = ret;
 	__vita_fdmap[fd]->type = is_dir ? VITA_DESCRIPTOR_DIRECTORY : VITA_DESCRIPTOR_FILE;
-	__vita_fdmap[fd]->filename = strdup(full_path);
+	if (is_dir) // needed only for dirs
+		__vita_fdmap[fd]->filename = strdup(full_path);
 
 	free(full_path);
 

--- a/newlib/libc/sys/vita/threading.c
+++ b/newlib/libc/sys/vita/threading.c
@@ -72,7 +72,8 @@ int vitasdk_delete_thread_reent(int thid)
 	return res;
 }
 
-int _exit_thread_common(int exit_status, int (*exit_func)(int)) {
+int _exit_thread_common(int exit_status, int (*exit_func)(int))
+{
 	int res = 0;
 	int ret = 0;
 	int thid = sceKernelGetThreadId();
@@ -99,11 +100,13 @@ int _exit_thread_common(int exit_status, int (*exit_func)(int)) {
 	return ret;
 }
 
-int vita_exit_thread(int exit_status) {
+int vita_exit_thread(int exit_status)
+{
 	return _exit_thread_common(exit_status, sceKernelExitThread);
 }
 
-int vita_exit_delete_thread(int exit_status) {
+int vita_exit_delete_thread(int exit_status)
+{
 	return _exit_thread_common(exit_status, sceKernelExitDeleteThread);
 }
 
@@ -130,7 +133,8 @@ static inline struct reent_for_thread *__vita_allocate_reent(void)
 	struct reent_for_thread *free_reent = 0;
 
 	for (i = 0; i < MAX_THREADS; ++i)
-		if (reent_list[i].thread_id == 0) {
+		if (reent_list[i].thread_id == 0)
+		{
 			free_reent = &reent_list[i];
 			break;
 		}
@@ -138,7 +142,8 @@ static inline struct reent_for_thread *__vita_allocate_reent(void)
 	return free_reent;
 }
 
-struct _reent *__getreent_for_thread(int thid) {
+struct _reent *__getreent_for_thread(int thid)
+{
 	struct reent_for_thread *free_reent = 0;
 	struct _reent *returned_reent = 0;
 
@@ -150,7 +155,8 @@ struct _reent *__getreent_for_thread(int thid) {
 	else
 		on_tls = TLS_REENT_THID_PTR(thid);	
 	
-	if (*on_tls) {
+	if (*on_tls)
+	{
 		return *on_tls;
 	}
   
@@ -160,20 +166,25 @@ struct _reent *__getreent_for_thread(int thid) {
 	// We allocate one and put a pointer to it on the TLS
 	free_reent = __vita_allocate_reent();
 
-	if (!free_reent) {
+	if (!free_reent)
+	{
 		// clean any hanging thread references
 		__vita_clean_reent();
 
 		free_reent = __vita_allocate_reent();
 
-		if (!free_reent) {
+		if (!free_reent)
+		{
 			// we've exhausted all our resources
 			sceClibPrintf("[VITASDK] FATAL: Exhausted all thread reent resources!");
 			__builtin_trap();
 		}
-	} else {
+	}
+	else
+	{
 		// First, check if it needs to be cleaned up (if it came from another thread)
-		if (free_reent->needs_reclaim) {
+		if (free_reent->needs_reclaim)
+		{
 			_reclaim_reent(&free_reent->reent);
 			free_reent->needs_reclaim = 0;
 		}
@@ -181,7 +192,8 @@ struct _reent *__getreent_for_thread(int thid) {
 		memset(free_reent, 0, sizeof(struct reent_for_thread));
 
 		// Set it up
-		if(thid==0){
+		if(thid==0)
+		{
 			thid = sceKernelGetThreadId();
 		}
 		free_reent->thread_id = thid;
@@ -196,7 +208,8 @@ struct _reent *__getreent_for_thread(int thid) {
 	return returned_reent;
 }
 
-struct _reent *__getreent(void) {
+struct _reent *__getreent(void)
+{
 	return  __getreent_for_thread(0);
 }
 
@@ -219,7 +232,8 @@ void *vitasdk_get_pthread_data(SceUID thid)
 }
 
 // Called from _start to set up the main thread reentrancy structure
-void _init_vita_reent(void) {
+void _init_vita_reent(void)
+{
 	memset(reent_list, 0, sizeof(reent_list));
 	_newlib_reent_mutex = sceKernelCreateMutex("reent list access mutex", 0, 0, 0);
 	reent_list[0].thread_id = sceKernelGetThreadId();
@@ -228,6 +242,7 @@ void _init_vita_reent(void) {
 	_REENT_INIT_PTR(&_newlib_global_reent);
 }
 
-void _free_vita_reent(void) {
+void _free_vita_reent(void)
+{
 	sceKernelDeleteMutex(_newlib_reent_mutex);
 }

--- a/newlib/libc/sys/vita/vitadescriptor.h
+++ b/newlib/libc/sys/vita/vitadescriptor.h
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.
 typedef enum
 {
 	VITA_DESCRIPTOR_FILE,
+	VITA_DESCRIPTOR_DIRECTORY,
 	VITA_DESCRIPTOR_SOCKET,
 	VITA_DESCRIPTOR_TTY
 } DescriptorTypes;
@@ -40,6 +41,7 @@ typedef struct
 	int sce_uid;
 	DescriptorTypes type;
 	int ref_count;
+	char* filename;
 } DescriptorTranslation;
 
 extern DescriptorTranslation *__vita_fdmap[];

--- a/newlib/libc/sys/vita/vitaerror.h
+++ b/newlib/libc/sys/vita/vitaerror.h
@@ -26,7 +26,17 @@ DEALINGS IN THE SOFTWARE.
 #ifndef _VITAERROR_H_
 #define _VITAERROR_H_
 
-int __vita_sce_errno_to_errno(int sce_errno);
+#define SCE_ERRNO_MASK 0xFF
+#define SCE_ERRNO_NONE 0x80010000
+typedef enum
+{
+    ERROR_GENERIC,
+    ERROR_SOCKET
+} ErrorType;
+
+int __vita_scenet_errno_to_errno(int sce_errno);
+int __vita_sce_errno_to_errno(int sce_errno, int type);
+int __vita_make_sce_errno(int posix_errno);
 
 #endif // _VITAERROR_H_
 

--- a/newlib/libc/sys/vita/vitafs.h
+++ b/newlib/libc/sys/vita/vitafs.h
@@ -1,7 +1,6 @@
 /*
 
-Copyright (C) 2016, David "Davee" Morgan
-Copyright (C) 2020, Francisco José García García
+Copyright (C) 2021, vitasdk
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -23,11 +22,10 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
-#include <sys/types.h>
+#ifndef _VITAFS_H_
+#define _VITAFS_H_
 
-#include <psp2/kernel/threadmgr.h>
+char *__realpath(const char *path);
+int __is_dir(const char *path);
 
-int usleep(unsigned useconds)
-{
-	return sceKernelDelayThread(useconds);
-}
+#endif // _VITAFS_H_


### PR DESCRIPTION
* add getcwd/chdir implementations.
* Rewrite open/mkdir/etc. to use cwd.
* Reformat code to follow one coding standard (we can discuss and reformat that later, for now i choose one that was used mostly through code).
* Rewrite error handling.
* rewrite dirent to use open/close and vita fdmap.
* add fdopendir/scandir/dirfd/alphasort.
* add fsync
* add support for opening directories with `open`
* fix getentropy to allow 256 buffer

This effectively makes #63 and #64 obsolete. Also fixes #8 due to path checking and #36.
I did some basic tests and everything seems to work, but it still requires thorough review and testing.