### PR TITLE
Expose lstat

### DIFF
--- a/newlib/libc/sys/vita/sys/stat.h
+++ b/newlib/libc/sys/vita/sys/stat.h
@@ -146,8 +146,8 @@ int	mkfifo (const char *__path, mode_t __mode );
 int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
 mode_t	umask (mode_t __mask );
 
-#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
 int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
+#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) && !defined(__INSIDE_CYGWIN__)
 int	mknod (const char *__path, mode_t __mode, dev_t __dev );
 #endif
 


### PR DESCRIPTION
We do have lstat, so expose it in headers.
Fixes cpython build.