### PR TITLE
Net autoinit

### DIFF
--- a/newlib/libc/sys/vita/Makefile.am
+++ b/newlib/libc/sys/vita/Makefile.am
@@ -10,10 +10,10 @@ noinst_LIBRARIES = lib.a
 
 SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o error.o
 NET_OBJS = gethostbyaddr.o gethostbyname.o getaddrinfo.o freeaddrinfo.o getservbyname.o \
-	inet_ntop.o inet_ntoa.o inet_netof.o inet_pton.o inet_lnaof.o inet_addr.o inet_network.o inet_net_ntop.o inet_aton.o inet_net_pton.o inet_makeaddr.o
+	inet_ntop.o inet_ntoa.o inet_netof.o inet_pton.o inet_lnaof.o inet_addr.o inet_network.o inet_net_ntop.o inet_aton.o inet_net_pton.o inet_makeaddr.o vitanet.o
 DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
 
-NET_SOURCES = net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c
+NET_SOURCES = net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c vitanet.c
 STUB_SOURCES = chroot.c groups.c
 lib_a_SOURCES = syscalls.c access.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c error.c dirent.c \
 	lcltime_r.c sleep.c usleep.c truncate.c fs.c clock.c pread.c pathconf.c fpathconf.c poll.c monetary.c uname.c getentropy.c \
@@ -28,7 +28,7 @@ all-local: crt0.o
 $(SOCKET_OBJS): socket.c error.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
-$(NET_OBJS): net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c
+$(NET_OBJS): net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c vitanet.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
 $(DIRENT_OBJS): dirent.c

--- a/newlib/libc/sys/vita/Makefile.in
+++ b/newlib/libc/sys/vita/Makefile.in
@@ -78,7 +78,7 @@ am__objects_2 = lib_a-gethostbyaddr.$(OBJEXT) \
 	lib_a-inet_lnaof.$(OBJEXT) lib_a-inet_addr.$(OBJEXT) \
 	lib_a-inet_network.$(OBJEXT) lib_a-inet_net_ntop.$(OBJEXT) \
 	lib_a-inet_aton.$(OBJEXT) lib_a-inet_net_pton.$(OBJEXT) \
-	lib_a-inet_makeaddr.$(OBJEXT)
+	lib_a-inet_makeaddr.$(OBJEXT) lib_a-vitanet.$(OBJEXT)
 am_lib_a_OBJECTS = lib_a-syscalls.$(OBJEXT) lib_a-access.$(OBJEXT) \
 	lib_a-sbrk.$(OBJEXT) lib_a-threading.$(OBJEXT) \
 	lib_a-mlock.$(OBJEXT) lib_a-io.$(OBJEXT) \
@@ -223,10 +223,10 @@ AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
 SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o error.o
 NET_OBJS = gethostbyaddr.o gethostbyname.o getaddrinfo.o freeaddrinfo.o getservbyname.o \
-	net_ntop.o inet_ntoa.o inet_netof.o inet_pton.o inet_lnaof.o inet_addr.o inet_network.o inet_net_ntop.o inet_aton.o inet_net_pton.o inet_makeaddr.o
+	net_ntop.o inet_ntoa.o inet_netof.o inet_pton.o inet_lnaof.o inet_addr.o inet_network.o inet_net_ntop.o inet_aton.o inet_net_pton.o inet_makeaddr.o vitanet.o
 DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
 NET_SOURCES = net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c \
-	net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c
+	net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c vitanet.c
 STUB_SOURCES = chroot.c groups.c
 lib_a_SOURCES = syscalls.c access.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c error.c dirent.c \
 	lcltime_r.c sleep.c usleep.c truncate.c fs.c clock.c pread.c pathconf.c fpathconf.c poll.c monetary.c uname.c getentropy.c \
@@ -589,6 +589,12 @@ lib_a-inet_makeaddr.o: net/inet_makeaddr.c
 lib_a-inet_makeaddr.obj: net/inet_makeaddr.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-inet_makeaddr.obj `if test -f 'net/inet_makeaddr.c'; then $(CYGPATH_W) 'net/inet_makeaddr.c'; else $(CYGPATH_W) '$(srcdir)/net/inet_makeaddr.c'; fi`
 
+lib_a-vitanet.o: vitanet.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-vitanet.o `test -f 'vitanet.c' || echo '$(srcdir)/'`vitanet.c
+
+lib_a-vitanet.obj: vitanet.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-vitanet.obj `if test -f 'vitanet.c'; then $(CYGPATH_W) 'vitanet.c'; else $(CYGPATH_W) '$(srcdir)/vitanet.c'; fi`
+
 ID: $(HEADERS) $(SOURCES) $(LISP) $(TAGS_FILES)
 	list='$(SOURCES) $(HEADERS) $(LISP) $(TAGS_FILES)'; \
 	unique=`for i in $$list; do \
@@ -765,7 +771,7 @@ all-local: crt0.o
 $(SOCKET_OBJS): socket.c error.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
-$(NET_OBJS): net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c
+$(NET_OBJS): net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c vitanet.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
 $(DIRENT_OBJS): dirent.c

--- a/newlib/libc/sys/vita/error.c
+++ b/newlib/libc/sys/vita/error.c
@@ -45,174 +45,174 @@ int __vita_make_sce_errno(int posix_errno)
 
 int __vita_scenet_errno_to_errno(int sce_errno)
 {
-	switch (sce_errno)
+	switch (sce_errno & SCE_ERRNO_MASK)
 	{
-		case SCE_NET_ERROR_EPERM:
+		case SCE_NET_EPERM:
 			return EPERM;
-		case SCE_NET_ERROR_ENOENT:
+		case SCE_NET_ENOENT:
 			return ENOENT;
-		case SCE_NET_ERROR_ESRCH:
+		case SCE_NET_ESRCH:
 			return ESRCH;
-		case SCE_NET_ERROR_EINTR:
+		case SCE_NET_EINTR:
 			return EINTR;
-		case SCE_NET_ERROR_EIO:
+		case SCE_NET_EIO:
 			return EIO;
-		case SCE_NET_ERROR_ENXIO:
+		case SCE_NET_ENXIO:
 			return ENXIO;
-		case SCE_NET_ERROR_E2BIG:
+		case SCE_NET_E2BIG:
 			return E2BIG;
-		case SCE_NET_ERROR_ENOEXEC:
+		case SCE_NET_ENOEXEC:
 			return ENOEXEC;
-		case SCE_NET_ERROR_EBADF:
+		case SCE_NET_EBADF:
 			return EBADF;
-		case SCE_NET_ERROR_ECHILD:
+		case SCE_NET_ECHILD:
 			return ECHILD;
-		case SCE_NET_ERROR_EDEADLK:
+		case SCE_NET_EDEADLK:
 			return EDEADLK;
-		case SCE_NET_ERROR_ENOMEM:
+		case SCE_NET_ENOMEM:
 			return ENOMEM;
-		case SCE_NET_ERROR_EACCES:
+		case SCE_NET_EACCES:
 			return EACCES;
-		case SCE_NET_ERROR_EFAULT:
+		case SCE_NET_EFAULT:
 			return EFAULT;
-		case SCE_NET_ERROR_ENOTBLK:
+		case SCE_NET_ENOTBLK:
 			return ENOTBLK;
-		case SCE_NET_ERROR_EBUSY:
+		case SCE_NET_EBUSY:
 			return EBUSY;
-		case SCE_NET_ERROR_EEXIST:
+		case SCE_NET_EEXIST:
 			return EEXIST;
-		case SCE_NET_ERROR_EXDEV:
+		case SCE_NET_EXDEV:
 			return EXDEV;
-		case SCE_NET_ERROR_ENODEV:
+		case SCE_NET_ENODEV:
 			return ENODEV;
-		case SCE_NET_ERROR_ENOTDIR:
+		case SCE_NET_ENOTDIR:
 			return ENOTDIR;
-		case SCE_NET_ERROR_EISDIR:
+		case SCE_NET_EISDIR:
 			return EISDIR;
-		case SCE_NET_ERROR_EINVAL:
+		case SCE_NET_EINVAL:
 			return EINVAL;
-		case SCE_NET_ERROR_ENFILE:
+		case SCE_NET_ENFILE:
 			return ENFILE;
-		case SCE_NET_ERROR_EMFILE:
+		case SCE_NET_EMFILE:
 			return EMFILE;
-		case SCE_NET_ERROR_ENOTTY:
+		case SCE_NET_ENOTTY:
 			return ENOTTY;
-		case SCE_NET_ERROR_ETXTBSY:
+		case SCE_NET_ETXTBSY:
 			return ETXTBSY;
-		case SCE_NET_ERROR_EFBIG:
+		case SCE_NET_EFBIG:
 			return EFBIG;
-		case SCE_NET_ERROR_ENOSPC:
+		case SCE_NET_ENOSPC:
 			return ENOSPC;
-		case SCE_NET_ERROR_ESPIPE:
+		case SCE_NET_ESPIPE:
 			return ESPIPE;
-		case SCE_NET_ERROR_EROFS:
+		case SCE_NET_EROFS:
 			return EROFS;
-		case SCE_NET_ERROR_EMLINK:
+		case SCE_NET_EMLINK:
 			return EMLINK;
-		case SCE_NET_ERROR_EPIPE:
+		case SCE_NET_EPIPE:
 			return EPIPE;
-		case SCE_NET_ERROR_EDOM:
+		case SCE_NET_EDOM:
 			return EDOM;
-		case SCE_NET_ERROR_ERANGE:
+		case SCE_NET_ERANGE:
 			return ERANGE;
-		case SCE_NET_ERROR_EAGAIN:
+		case SCE_NET_EAGAIN:
 			return EAGAIN;
 // these values are the same as EAGAIN
-//		case SCE_NET_ERROR_EWOULDBLOCK:
+//		case SCE_NET_EWOULDBLOCK:
 //			return EWOULDBLOCK;
-		case SCE_NET_ERROR_EINPROGRESS:
+		case SCE_NET_EINPROGRESS:
 			return EINPROGRESS;
-		case SCE_NET_ERROR_EALREADY:
+		case SCE_NET_EALREADY:
 			return EALREADY;
-		case SCE_NET_ERROR_ENOTSOCK:
+		case SCE_NET_ENOTSOCK:
 			return ENOTSOCK;
-		case SCE_NET_ERROR_EDESTADDRREQ:
+		case SCE_NET_EDESTADDRREQ:
 			return EDESTADDRREQ;
-		case SCE_NET_ERROR_EMSGSIZE:
+		case SCE_NET_EMSGSIZE:
 			return EMSGSIZE;
-		case SCE_NET_ERROR_EPROTOTYPE:
+		case SCE_NET_EPROTOTYPE:
 			return EPROTOTYPE;
-		case SCE_NET_ERROR_ENOPROTOOPT:
+		case SCE_NET_ENOPROTOOPT:
 			return ENOPROTOOPT;
-		case SCE_NET_ERROR_EPROTONOSUPPORT:
+		case SCE_NET_EPROTONOSUPPORT:
 			return EPROTONOSUPPORT;
-		case SCE_NET_ERROR_ESOCKTNOSUPPORT:
+		case SCE_NET_ESOCKTNOSUPPORT:
 			return ESOCKTNOSUPPORT;
-		case SCE_NET_ERROR_EOPNOTSUPP:
+		case SCE_NET_EOPNOTSUPP:
 			return EOPNOTSUPP;
-		case SCE_NET_ERROR_EPFNOSUPPORT:
+		case SCE_NET_EPFNOSUPPORT:
 			return EPFNOSUPPORT;
-		case SCE_NET_ERROR_EAFNOSUPPORT:
+		case SCE_NET_EAFNOSUPPORT:
 			return EAFNOSUPPORT;
-		case SCE_NET_ERROR_EADDRINUSE:
+		case SCE_NET_EADDRINUSE:
 			return EADDRINUSE;
-		case SCE_NET_ERROR_EADDRNOTAVAIL:
+		case SCE_NET_EADDRNOTAVAIL:
 			return EADDRNOTAVAIL;
-		case SCE_NET_ERROR_ENETDOWN:
+		case SCE_NET_ENETDOWN:
 			return ENETDOWN;
-		case SCE_NET_ERROR_ENETUNREACH:
+		case SCE_NET_ENETUNREACH:
 			return ENETUNREACH;
-		case SCE_NET_ERROR_ENETRESET:
+		case SCE_NET_ENETRESET:
 			return ENETRESET;
-		case SCE_NET_ERROR_ECONNABORTED:
+		case SCE_NET_ECONNABORTED:
 			return ECONNABORTED;
-		case SCE_NET_ERROR_ECONNRESET:
+		case SCE_NET_ECONNRESET:
 			return ECONNRESET;
-		case SCE_NET_ERROR_ENOBUFS:
+		case SCE_NET_ENOBUFS:
 			return ENOBUFS;
-		case SCE_NET_ERROR_EISCONN:
+		case SCE_NET_EISCONN:
 			return EISCONN;
-		case SCE_NET_ERROR_ENOTCONN:
+		case SCE_NET_ENOTCONN:
 			return ENOTCONN;
-		case SCE_NET_ERROR_ESHUTDOWN:
+		case SCE_NET_ESHUTDOWN:
 			return ESHUTDOWN;
-		case SCE_NET_ERROR_ETOOMANYREFS:
+		case SCE_NET_ETOOMANYREFS:
 			return ETOOMANYREFS;
-		case SCE_NET_ERROR_ETIMEDOUT:
+		case SCE_NET_ETIMEDOUT:
 			return ETIMEDOUT;
-		case SCE_NET_ERROR_ECONNREFUSED:
+		case SCE_NET_ECONNREFUSED:
 			return ECONNREFUSED;
-		case SCE_NET_ERROR_ELOOP:
+		case SCE_NET_ELOOP:
 			return ELOOP;
-		case SCE_NET_ERROR_ENAMETOOLONG:
+		case SCE_NET_ENAMETOOLONG:
 			return ENAMETOOLONG;
-		case SCE_NET_ERROR_EHOSTDOWN:
+		case SCE_NET_EHOSTDOWN:
 			return EHOSTDOWN;
-		case SCE_NET_ERROR_EHOSTUNREACH:
+		case SCE_NET_EHOSTUNREACH:
 			return EHOSTUNREACH;
-		case SCE_NET_ERROR_ENOTEMPTY:
+		case SCE_NET_ENOTEMPTY:
 			return ENOTEMPTY;
-		case SCE_NET_ERROR_EUSERS:
+		case SCE_NET_EUSERS:
 			return EUSERS;
-		case SCE_NET_ERROR_EDQUOT:
+		case SCE_NET_EDQUOT:
 			return EDQUOT;
-		case SCE_NET_ERROR_ESTALE:
+		case SCE_NET_ESTALE:
 			return ESTALE;
-		case SCE_NET_ERROR_EREMOTE:
+		case SCE_NET_EREMOTE:
 			return EREMOTE;
-		case SCE_NET_ERROR_ENOLCK:
+		case SCE_NET_ENOLCK:
 			return ENOLCK;
-		case SCE_NET_ERROR_ENOSYS:
+		case SCE_NET_ENOSYS:
 			return ENOSYS;
-		case SCE_NET_ERROR_EIDRM:
+		case SCE_NET_EIDRM:
 			return EIDRM;
-		case SCE_NET_ERROR_EOVERFLOW:
+		case SCE_NET_EOVERFLOW:
 			return EOVERFLOW;
-		case SCE_NET_ERROR_EILSEQ:
+		case SCE_NET_EILSEQ:
 			return EILSEQ;
-		case SCE_NET_ERROR_ENOTSUP:
+		case SCE_NET_ENOTSUP:
 			return ENOTSUP;
-		case SCE_NET_ERROR_ECANCELED:
+		case SCE_NET_ECANCELED:
 			return ECANCELED;
-		case SCE_NET_ERROR_EBADMSG:
+		case SCE_NET_EBADMSG:
 			return EBADMSG;
-		case SCE_NET_ERROR_ENODATA:
+		case SCE_NET_ENODATA:
 			return ENODATA;
-		case SCE_NET_ERROR_ENOSR:
+		case SCE_NET_ENOSR:
 			return ENOSR;
-		case SCE_NET_ERROR_ENOSTR:
+		case SCE_NET_ENOSTR:
 			return ENOSTR;
-		case SCE_NET_ERROR_ETIME:
+		case SCE_NET_ETIME:
 			return ETIME;
 		default:
 			return sce_errno;

--- a/newlib/libc/sys/vita/net/gethostbyaddr.c
+++ b/newlib/libc/sys/vita/net/gethostbyaddr.c
@@ -5,9 +5,11 @@
 #include <sys/socket.h>
 #include <psp2/net/net.h>
 #include "../vitaerror.h"
+#include "../vitanet.h"
 
 struct hostent *gethostbyaddr(const void *addr, socklen_t len, int type)
 {
+	_vita_net_init();
 	static struct hostent ent;
 	char name[NI_MAXHOST];
 	static char sname[NI_MAXHOST] = "";

--- a/newlib/libc/sys/vita/net/gethostbyname.c
+++ b/newlib/libc/sys/vita/net/gethostbyname.c
@@ -4,11 +4,13 @@
 #include <errno.h>
 #include <psp2/net/net.h>
 #include "../vitaerror.h"
+#include "../vitanet.h"
 
 #define MAX_NAME 512
 
 struct hostent *gethostbyname(const char *name)
 {
+	_vita_net_init();
 	static struct hostent ent;
 	static char sname[MAX_NAME] = "";
 	static struct SceNetInAddr saddr = {0};

--- a/newlib/libc/sys/vita/net/inet_ntop.c
+++ b/newlib/libc/sys/vita/net/inet_ntop.c
@@ -26,10 +26,20 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <psp2/net/net.h>
+#include "../vitanet.h"
+#include "../vitaerror.h"
 
 #define SPRINTF(x) ((socklen_t) sprintf x)
 
-#define inet_ntop4(src, dst, size) sceNetInetNtop(AF_INET, src, dst, size)
+static const char *inet_ntop4(const void *src, char *dst, socklen_t size)
+{
+	const char* ret = sceNetInetNtop(AF_INET, src, dst, size);
+	if (!ret)
+	{
+		errno = __vita_scenet_errno_to_errno(scenet_errno);
+	}
+	return ret;
+}
 
 static const char *inet_ntop6(const u_char *src, char *dst, socklen_t size)
 {
@@ -141,9 +151,11 @@ const char *inet_ntop(int af, const void *src, char *dst, socklen_t size)
 {
 	switch (af) {
 	case AF_INET:
+		_vita_net_init();
 		return inet_ntop4(src, dst, size);
 
 	case AF_INET6:
+		_vita_net_init();
 		return inet_ntop6(src, dst, size);
 
 	default:

--- a/newlib/libc/sys/vita/net/inet_pton.c
+++ b/newlib/libc/sys/vita/net/inet_pton.c
@@ -26,8 +26,18 @@
 #include <string.h>
 #include <sys/types.h>
 #include <psp2/net/net.h>
+#include "../vitanet.h"
+#include "../vitaerror.h"
 
-#define inet_pton4(src, dst) sceNetInetPton(AF_INET, src, dst)
+static int inet_pton4(const char *src, void *dst)
+{
+	int ret = sceNetInetPton(AF_INET, src, dst);
+	if (!dst)
+	{
+		errno = __vita_scenet_errno_to_errno(scenet_errno);
+	}
+	return (ret < 0) ? -1 : ret;
+}
 
 static int inet_pton6(const char *src, u_char *dst)
 {
@@ -134,9 +144,11 @@ int inet_pton(int af, const char *src, void *dst)
 {
 	switch (af) {
 	case AF_INET:
+		_vita_net_init();
 		return inet_pton4(src, dst);
 
 	case AF_INET6:
+		_vita_net_init();
 		return inet_pton6(src, dst);
 
 	default:

--- a/newlib/libc/sys/vita/socket.c
+++ b/newlib/libc/sys/vita/socket.c
@@ -25,12 +25,14 @@ DEALINGS IN THE SOFTWARE.
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include <psp2/net/net.h>
 #include <psp2/types.h>
 
 #include "vitadescriptor.h"
 #include "vitaerror.h"
+#include "vitanet.h"
 
 static inline int is_socket_valid(int s)
 {
@@ -447,6 +449,7 @@ int	shutdown(int s, int how)
 #ifdef F_socket
 int	socket(int domain, int type, int protocol)
 {
+	_vita_net_init();
 	int res = sceNetSocket("", domain, type, protocol);
 
 	if (res < 0)

--- a/newlib/libc/sys/vita/vitanet.c
+++ b/newlib/libc/sys/vita/vitanet.c
@@ -1,0 +1,93 @@
+/*
+
+Copyright (C) 2022, vitasdk
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <psp2/net/net.h>
+#include <psp2/net/netctl.h>
+#include <psp2/sysmodule.h>
+#include <psp2/types.h>
+#include <stdlib.h>
+
+#include "vitanet.h"
+
+// theoretical maximum:
+// 128 bytes per socket, 1024 sockets max
+// 4KiB reserved
+// 3KiB - basic features
+// 4KiB - dns cache
+// 1300 bytes - dns resolver
+#define NET_MEM_SIZE (128*1024 + ((4+3+4) * 1024)) + 1300
+
+#ifndef SCE_NET_CTL_ERROR_NOT_TERMINATED
+#define SCE_NET_CTL_ERROR_NOT_TERMINATED 0x80412102
+#endif
+
+static void *_vita_net_memory = NULL;
+
+int _vita_net_init()
+{
+	int ret;
+	SceNetInitParam net_init_param = {0};
+
+	if (sceSysmoduleIsLoaded(SCE_SYSMODULE_NET) != SCE_SYSMODULE_LOADED)
+	{
+		ret = sceSysmoduleLoadModule(SCE_SYSMODULE_NET);
+		if (ret < 0)
+		{
+			return ret;
+		}
+	}
+
+	_vita_net_memory = malloc(NET_MEM_SIZE);
+	if (!_vita_net_memory)
+	{
+		return SCE_NET_ENOMEM;
+	}
+
+	net_init_param.memory = _vita_net_memory;
+	net_init_param.size = NET_MEM_SIZE;
+	net_init_param.flags = 0;
+
+	// try to init. If it's already inited we'll get SCE_NET_ERROR_EBUSY
+	ret = sceNetInit(&net_init_param);
+	if (ret < 0)
+	{
+		free(_vita_net_memory);
+		if (ret != SCE_NET_ERROR_EBUSY)
+			return ret;
+	}
+
+	ret = sceNetCtlInit();
+	if (ret < 0)
+	{
+		if (ret != SCE_NET_CTL_ERROR_NOT_TERMINATED)
+		{
+			// something gone wrong, tear down completely, so it can be re-inited
+			// and we won't leak mem
+			sceNetTerm();
+			free(_vita_net_memory);
+		}
+		return ret;
+	}
+}
+

--- a/newlib/libc/sys/vita/vitanet.c
+++ b/newlib/libc/sys/vita/vitanet.c
@@ -43,10 +43,14 @@ DEALINGS IN THE SOFTWARE.
 #endif
 
 static void *_vita_net_memory = NULL;
+static int _vita_net_initialized = 0;
 
 int _vita_net_init()
 {
 	int ret;
+
+	if (_vita_net_initialized) return 0;
+
 	SceNetInitParam net_init_param = {0};
 
 	if (sceSysmoduleIsLoaded(SCE_SYSMODULE_NET) != SCE_SYSMODULE_LOADED)
@@ -73,6 +77,7 @@ int _vita_net_init()
 	if (ret < 0)
 	{
 		free(_vita_net_memory);
+		_vita_net_memory = NULL;
 		if (ret != SCE_NET_ERROR_EBUSY)
 			return ret;
 	}
@@ -84,10 +89,17 @@ int _vita_net_init()
 		{
 			// something gone wrong, tear down completely, so it can be re-inited
 			// and we won't leak mem
-			sceNetTerm();
-			free(_vita_net_memory);
+			if (_vita_net_memory != NULL) // if we inited net successfully - cleanup
+			{
+				sceNetTerm();
+				free(_vita_net_memory);
+			}
+			return ret;
 		}
-		return ret;
 	}
+
+	_vita_net_initialized = 1;
+
+	return 0;
 }
 

--- a/newlib/libc/sys/vita/vitanet.h
+++ b/newlib/libc/sys/vita/vitanet.h
@@ -1,0 +1,33 @@
+/*
+
+Copyright (C) 2022, vitasdk
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+*/
+
+#ifndef _VITANET_H_
+#define _VITANET_H_
+
+#include <psp2/net/net.h>
+int _vita_net_init();
+
+#define scenet_errno (*sceNetErrnoLoc())
+
+#endif // _VITANET_H_


### PR DESCRIPTION
* Implement network auto-initialization on first call to net-related function
* Fix inet_ntop/inet_pton error handling (error handling changed due to scenet_errno returning SceNetKernelErrorCode instead of SceNetErrorCode)

Requires https://github.com/vitasdk/buildscripts/pull/112