### PR TITLE
Fix multiple definitions of funcs in dirent.c and net/*

### DIFF
--- a/newlib/libc/sys/vita/Makefile.am
+++ b/newlib/libc/sys/vita/Makefile.am
@@ -8,27 +8,41 @@ AM_CCASFLAGS = $(INCLUDES)
 
 noinst_LIBRARIES = lib.a
 
-SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o error.o
-NET_OBJS = gethostbyaddr.o gethostbyname.o getaddrinfo.o freeaddrinfo.o getservbyname.o \
-	inet_ntop.o inet_ntoa.o inet_netof.o inet_pton.o inet_lnaof.o inet_addr.o inet_network.o inet_net_ntop.o inet_aton.o inet_net_pton.o inet_makeaddr.o gethostname.o vitanet.o
-DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
+SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o
+DIRENT_OBJS = dirfd.o closedir.o opendir.o readdir.o readdir_r.o rewinddir.o scandir.o seekdir.o telldir.o 
 
-NET_SOURCES = net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c net/gethostname.c vitanet.c
+NET_SOURCES = net/gethostbyaddr.c \
+	net/gethostbyname.c \
+	net/getaddrinfo.c \
+	net/freeaddrinfo.c \
+	net/getservbyname.c \
+	net/inet_ntop.c \
+	net/inet_ntoa.c \
+	net/inet_netof.c \
+	net/inet_pton.c \
+	net/inet_lnaof.c \
+	net/inet_addr.c \
+	net/inet_network.c \
+	net/inet_net_ntop.c \
+	net/inet_aton.c \
+	net/inet_net_pton.c \
+	net/inet_makeaddr.c \
+	net/gethostname.c \
+	vitanet.c
+
 STUB_SOURCES = chroot.c groups.c
+
 lib_a_SOURCES = syscalls.c access.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c error.c dirent.c \
 	lcltime_r.c sleep.c usleep.c truncate.c fs.c clock.c pread.c pathconf.c fpathconf.c poll.c monetary.c uname.c getentropy.c \
 	basename.c dirname.c resource.c sysconf.c ids.c secure_getenv.c pipe.c utime.c\
 	${STUB_SOURCES} ${NET_SOURCES}
-lib_a_LIBADD = ${SOCKET_OBJS} ${NET_OBJS} ${DIRENT_OBJS}
+lib_a_LIBADD = ${SOCKET_OBJS} ${DIRENT_OBJS}
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
 
 all-local: crt0.o
 
-$(SOCKET_OBJS): socket.c error.c
-	$(COMPILE) -DF_$* $< -c -o $@
-
-$(NET_OBJS): net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c net/gethostname.c vitanet.c
+$(SOCKET_OBJS): socket.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
 $(DIRENT_OBJS): dirent.c

--- a/newlib/libc/sys/vita/Makefile.in
+++ b/newlib/libc/sys/vita/Makefile.in
@@ -68,7 +68,7 @@ CONFIG_CLEAN_VPATH_FILES =
 LIBRARIES = $(noinst_LIBRARIES)
 ARFLAGS = cru
 lib_a_AR = $(AR) $(ARFLAGS)
-lib_a_DEPENDENCIES = $(SOCKET_OBJS) $(NET_OBJS) $(DIRENT_OBJS)
+lib_a_DEPENDENCIES = $(SOCKET_OBJS) $(DIRENT_OBJS)
 am__objects_1 = lib_a-chroot.$(OBJEXT) lib_a-groups.$(OBJEXT)
 am__objects_2 = lib_a-gethostbyaddr.$(OBJEXT) \
 	lib_a-gethostbyname.$(OBJEXT) lib_a-getaddrinfo.$(OBJEXT) \
@@ -95,8 +95,8 @@ am_lib_a_OBJECTS = lib_a-syscalls.$(OBJEXT) lib_a-access.$(OBJEXT) \
 	lib_a-basename.$(OBJEXT) lib_a-dirname.$(OBJEXT) \
 	lib_a-resource.$(OBJEXT) lib_a-sysconf.$(OBJEXT) \
 	lib_a-ids.$(OBJEXT) lib_a-secure_getenv.$(OBJEXT) \
-	lib_a-pipe.$(OBJEXT) lib_a-utime.$(OBJEXT)\
-	$(am__objects_1) $(am__objects_2)
+	lib_a-pipe.$(OBJEXT) lib_a-utime.$(OBJEXT) $(am__objects_1) \
+	$(am__objects_2)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@
 depcomp =
@@ -222,18 +222,34 @@ AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 AM_CCASFLAGS = $(INCLUDES)
 noinst_LIBRARIES = lib.a
-SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o error.o
-NET_OBJS = gethostbyaddr.o gethostbyname.o getaddrinfo.o freeaddrinfo.o getservbyname.o \
-	net_ntop.o inet_ntoa.o inet_netof.o inet_pton.o inet_lnaof.o inet_addr.o inet_network.o inet_net_ntop.o inet_aton.o inet_net_pton.o inet_makeaddr.o gethostname.o vitanet.o
-DIRENT_OBJS = closedir.o opendir.o readdir.o readdir_r.o rewinddir.o seekdir.o telldir.o
-NET_SOURCES = net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c \
-	net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c net/gethostname.c vitanet.c
+SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o
+DIRENT_OBJS = dirfd.o closedir.o opendir.o readdir.o readdir_r.o rewinddir.o scandir.o seekdir.o telldir.o 
+NET_SOURCES = net/gethostbyaddr.c \
+	net/gethostbyname.c \
+	net/getaddrinfo.c \
+	net/freeaddrinfo.c \
+	net/getservbyname.c \
+	net/inet_ntop.c \
+	net/inet_ntoa.c \
+	net/inet_netof.c \
+	net/inet_pton.c \
+	net/inet_lnaof.c \
+	net/inet_addr.c \
+	net/inet_network.c \
+	net/inet_net_ntop.c \
+	net/inet_aton.c \
+	net/inet_net_pton.c \
+	net/inet_makeaddr.c \
+	net/gethostname.c \
+	vitanet.c
+
 STUB_SOURCES = chroot.c groups.c
 lib_a_SOURCES = syscalls.c access.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c error.c dirent.c \
 	lcltime_r.c sleep.c usleep.c truncate.c fs.c clock.c pread.c pathconf.c fpathconf.c poll.c monetary.c uname.c getentropy.c \
 	basename.c dirname.c resource.c sysconf.c ids.c secure_getenv.c pipe.c utime.c\
 	${STUB_SOURCES} ${NET_SOURCES}
-lib_a_LIBADD = ${SOCKET_OBJS} ${NET_OBJS} ${DIRENT_OBJS}
+
+lib_a_LIBADD = ${SOCKET_OBJS} ${DIRENT_OBJS}
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
 lib_a_CFLAGS = $(AM_CFLAGS)
 ACLOCAL_AMFLAGS = -I ../../.. -I ../../../..
@@ -404,24 +420,6 @@ lib_a-pread.o: pread.c
 lib_a-pread.obj: pread.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-pread.obj `if test -f 'pread.c'; then $(CYGPATH_W) 'pread.c'; else $(CYGPATH_W) '$(srcdir)/pread.c'; fi`
 
-lib_a-chroot.o: chroot.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-chroot.o `test -f 'chroot.c' || echo '$(srcdir)/'`chroot.c
-
-lib_a-chroot.obj: chroot.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-chroot.obj `if test -f 'chroot.c'; then $(CYGPATH_W) 'chroot.c'; else $(CYGPATH_W) '$(srcdir)/chroot.c'; fi`
-
-lib_a-getentropy.o: getentropy.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-getentropy.o `test -f 'getentropy.c' || echo '$(srcdir)/'`getentropy.c
-
-lib_a-getentropy.obj: getentropy.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-getentropy.obj `if test -f 'getentropy.c'; then $(CYGPATH_W) 'getentropy.c'; else $(CYGPATH_W) '$(srcdir)/getentropy.c'; fi`
-
-lib_a-groups.o: groups.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-groups.o `test -f 'groups.c' || echo '$(srcdir)/'`groups.c
-
-lib_a-groups.obj: groups.c
-	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-groups.obj `if test -f 'groups.c'; then $(CYGPATH_W) 'groups.c'; else $(CYGPATH_W) '$(srcdir)/groups.c'; fi`
-
 lib_a-pathconf.o: pathconf.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-pathconf.o `test -f 'pathconf.c' || echo '$(srcdir)/'`pathconf.c
 
@@ -451,6 +449,12 @@ lib_a-uname.o: uname.c
 
 lib_a-uname.obj: uname.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-uname.obj `if test -f 'uname.c'; then $(CYGPATH_W) 'uname.c'; else $(CYGPATH_W) '$(srcdir)/uname.c'; fi`
+
+lib_a-getentropy.o: getentropy.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-getentropy.o `test -f 'getentropy.c' || echo '$(srcdir)/'`getentropy.c
+
+lib_a-getentropy.obj: getentropy.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-getentropy.obj `if test -f 'getentropy.c'; then $(CYGPATH_W) 'getentropy.c'; else $(CYGPATH_W) '$(srcdir)/getentropy.c'; fi`
 
 lib_a-basename.o: basename.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-basename.o `test -f 'basename.c' || echo '$(srcdir)/'`basename.c
@@ -500,6 +504,17 @@ lib_a-utime.o: utime.c
 lib_a-utime.obj: utime.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-utime.obj `if test -f 'utime.c'; then $(CYGPATH_W) 'utime.c'; else $(CYGPATH_W) '$(srcdir)/utime.c'; fi`
 
+lib_a-chroot.o: chroot.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-chroot.o `test -f 'chroot.c' || echo '$(srcdir)/'`chroot.c
+
+lib_a-chroot.obj: chroot.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-chroot.obj `if test -f 'chroot.c'; then $(CYGPATH_W) 'chroot.c'; else $(CYGPATH_W) '$(srcdir)/chroot.c'; fi`
+
+lib_a-groups.o: groups.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-groups.o `test -f 'groups.c' || echo '$(srcdir)/'`groups.c
+
+lib_a-groups.obj: groups.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-groups.obj `if test -f 'groups.c'; then $(CYGPATH_W) 'groups.c'; else $(CYGPATH_W) '$(srcdir)/groups.c'; fi`
 
 lib_a-gethostbyaddr.o: net/gethostbyaddr.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-gethostbyaddr.o `test -f 'net/gethostbyaddr.c' || echo '$(srcdir)/'`net/gethostbyaddr.c
@@ -782,10 +797,7 @@ uninstall-am:
 
 all-local: crt0.o
 
-$(SOCKET_OBJS): socket.c error.c
-	$(COMPILE) -DF_$* $< -c -o $@
-
-$(NET_OBJS): net/gethostbyaddr.c net/gethostbyname.c net/getaddrinfo.c net/freeaddrinfo.c net/getservbyname.c net/inet_ntop.c net/inet_ntoa.c net/inet_netof.c net/inet_pton.c net/inet_lnaof.c net/inet_addr.c net/inet_network.c net/inet_net_ntop.c net/inet_aton.c net/inet_net_pton.c net/inet_makeaddr.c net/gethostname.c vitanet.c
+$(SOCKET_OBJS): socket.c
 	$(COMPILE) -DF_$* $< -c -o $@
 
 $(DIRENT_OBJS): dirent.c

--- a/newlib/libc/sys/vita/dirent.c
+++ b/newlib/libc/sys/vita/dirent.c
@@ -43,6 +43,7 @@ struct DIR_
 	int index;
 };
 
+#ifdef F_closedir
 int	closedir(DIR *dirp)
 {
 	if (!dirp || !dirp->fd)
@@ -62,7 +63,9 @@ int	closedir(DIR *dirp)
 	errno = 0;
 	return 0;
 }
+#endif
 
+#ifdef F_opendir
 DIR *__opendir_common(int fd)
 {
 	DIR *dirp = calloc(1, sizeof(DIR));
@@ -114,7 +117,9 @@ DIR *fdopendir(int fd)
 
 	return (__opendir_common(fd));
 }
+#endif
 
+#ifdef F_readdir
 struct dirent *readdir(DIR *dirp)
 {
 	if (!dirp)
@@ -150,7 +155,9 @@ struct dirent *readdir(DIR *dirp)
 	dirp->index++;
 	return dir;
 }
+#endif
 
+#ifdef F_rewinddir
 void rewinddir(DIR *dirp)
 {
 	if (!dirp)
@@ -182,7 +189,9 @@ void rewinddir(DIR *dirp)
 	dirp->index = 0;
 	errno = 0;
 }
+#endif
 
+#ifdef F_seekdir
 void seekdir(DIR *dirp, long int index)
 {
 	if (!dirp)
@@ -208,7 +217,9 @@ void seekdir(DIR *dirp, long int index)
 		}
 	}
 }
+#endif
 
+#ifdef F_telldir
 long int telldir(DIR *dirp)
 {
 	if (!dirp)
@@ -219,7 +230,9 @@ long int telldir(DIR *dirp)
 
 	return dirp->index;
 }
+#endif
 
+#ifdef F_dirfd
 int dirfd(DIR *dirp)
 {
 	if (!dirp)
@@ -230,7 +243,9 @@ int dirfd(DIR *dirp)
 
 	return dirp->fd;
 }
+#endif
 
+#ifdef F_readdir_r
 int readdir_r(DIR *restrict dirp, struct dirent *restrict entry, struct dirent **restrict result)
 {
 	*result = NULL;
@@ -247,7 +262,9 @@ int readdir_r(DIR *restrict dirp, struct dirent *restrict entry, struct dirent *
 	}
 	return 0;
 }
+#endif
 
+#ifdef F_scandir
 int
 alphasort(const struct dirent **d1, const struct dirent **d2)
 {
@@ -296,3 +313,4 @@ int scandir(const char *path, struct dirent ***res,
 	*res = names;
 	return cnt;
 }
+#endif


### PR DESCRIPTION
* Use ifdef guards in dirent
* Build net/* sources normally, since they follow function-per-file convention