### PR TITLE
Increase default newlib heap size to 128 MB.

### DIFF
--- a/newlib/libc/sys/vita/sbrk.c
+++ b/newlib/libc/sys/vita/sbrk.c
@@ -43,8 +43,8 @@ void _init_vita_heap(void)
 	}
 	else
 	{
-		// Create a memblock for the heap memory, 32MB
-		_newlib_heap_size = 32 * 1024 * 1024;
+		// Create a memblock for the heap memory, 128MB
+		_newlib_heap_size = 128 * 1024 * 1024;
 	}
 	_newlib_heap_memblock = sceKernelAllocMemBlock("Newlib heap", 0x0c20d060, _newlib_heap_size, 0);
 	if (_newlib_heap_memblock < 0)


### PR DESCRIPTION
The original 32 MB default size is just way too undersized and most homebrews, even basic ones, require to manually increase it making developing for Vita from newcomers just counter-intuitive.

128 MB is a best choice for a default value since applications very intensive with sceKernelAllocMemBlock can still lower it using `_newlib_heap_size_user` and at the same time it offers a good balance between dynamic memory available through newlib and memblocks.