### PR TITLE
Implemented non-blocking pipe and socketpair

### DIFF
--- a/newlib/libc/sys/vita/Makefile.am
+++ b/newlib/libc/sys/vita/Makefile.am
@@ -8,7 +8,7 @@ AM_CCASFLAGS = $(INCLUDES)
 
 noinst_LIBRARIES = lib.a
 
-SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o
+SOCKET_OBJS = accept.o bind.o connect.o getpeername.o getsockname.o getsockopt.o listen.o recv.o recvfrom.o recvmsg.o send.o sendto.o sendmsg.o setsockopt.o shutdown.o socket.o socketpair.o
 DIRENT_OBJS = dirfd.o closedir.o opendir.o readdir.o readdir_r.o rewinddir.o scandir.o seekdir.o telldir.o 
 
 NET_SOURCES = net/gethostbyaddr.c \

--- a/newlib/libc/sys/vita/sys/socket.h
+++ b/newlib/libc/sys/vita/sys/socket.h
@@ -279,6 +279,7 @@ ssize_t sendmsg(int s, const struct msghdr *msg, int flags);
 int	setsockopt(int, int, int, const void *, socklen_t);
 int	shutdown(int, int);
 int	socket(int, int, int);
+int	socketpair(int, int, int, int *);
 
 #ifdef __cplusplus
 }

--- a/newlib/libc/sys/vita/syscalls.c
+++ b/newlib/libc/sys/vita/syscalls.c
@@ -54,8 +54,9 @@ _write_r(struct _reent * reent, int fd, const void *buf, size_t nbytes)
 		{
 			size_t len = nbytes;
 			if (len > 4 * 4096) len = 4 * 4096;
-			ret = sceKernelSendMsgPipe(fdmap->sce_uid, buf, len, 1, NULL, NULL);
-			if (ret == 0) ret = len;
+			size_t p_res = 0;
+			ret = sceKernelSendMsgPipe(fdmap->sce_uid, buf, len, 1, &p_res, NULL);
+			if (ret == 0) ret = p_res;
 			break;
 		}
 	}
@@ -336,8 +337,9 @@ _read_r(struct _reent *reent, int fd, void *ptr, size_t len)
 		{
 			size_t rlen = len;
 			if (rlen > 4 * 4096) rlen = 4 * 4096;
-			ret = sceKernelReceiveMsgPipe(fdmap->sce_uid, ptr, rlen, 1, NULL, NULL);
-			if (ret == 0) ret = rlen;
+			size_t p_res = 0;
+			ret = sceKernelReceiveMsgPipe(fdmap->sce_uid, ptr, rlen, 1, &p_res, NULL);
+			if (ret == 0) ret = p_res;
 			break;
 		}
 	}


### PR DESCRIPTION
Motivation:

In Rust ecosystem many libraries rely on a `tokio` async runtime, which internally requires nonblocking unix pipes (as a fallback for os'es without epoll or kqueue).

This PR contains:

- Added `socketpair` call. This just creates a IPV4 socket pair yolo ignoring the domain passed as an argument since usually `socketpair` is used with `AF_UNIX`, and they are not supported
- Added `pipe2` call for nonblocking unix pipes. Depending on the options it delegates either to the original `pipe` or to `sockerpair` call. This allows having `select`, `poll`, `read`, `write` calls for nonblocking pipes without any additional code, because pipe in that case is just a pair of sockets. `fcntl` is not implemented, since I don't want to touch/break the original `pipe` implementation in case blocking pipes are needed.
- Fixed `read` and `write` calls for pipes, previously they returned buffer length instead of actually read bytes length