### PR TITLE
Added fcntl, fixed errno in socketpair and pipe2, added linger=0 for pipes

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -703,7 +703,7 @@ newlib_cflags="${newlib_cflags} -DCLOCK_PROVIDED -DMALLOC_PROVIDED -DEXIT_PROVID
 	;;
   arm*vita*)
 	syscall_dir=syscalls
-	newlib_cflags="${newlib_cflags} -D__DYNAMIC_REENT__ -DREENTRANT_SYSCALLS_PROVIDED -DGETREENT_PROVIDED"
+	newlib_cflags="${newlib_cflags} -D__DYNAMIC_REENT__ -DREENTRANT_SYSCALLS_PROVIDED -DGETREENT_PROVIDED -DHAVE_FCNTL"
 	;;
   arm*-*-pe)
 	syscall_dir=syscalls

--- a/newlib/libc/sys/vita/Makefile.am
+++ b/newlib/libc/sys/vita/Makefile.am
@@ -32,7 +32,7 @@ NET_SOURCES = net/gethostbyaddr.c \
 
 STUB_SOURCES = chroot.c groups.c
 
-lib_a_SOURCES = syscalls.c access.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c error.c dirent.c \
+lib_a_SOURCES = syscalls.c access.c sbrk.c threading.c mlock.c io.c socket.c dup.c select.c error.c fcntl.c dirent.c \
 	lcltime_r.c sleep.c usleep.c truncate.c fs.c clock.c pread.c pathconf.c fpathconf.c poll.c monetary.c uname.c getentropy.c \
 	basename.c dirname.c resource.c sysconf.c ids.c secure_getenv.c pipe.c utime.c\
 	${STUB_SOURCES} ${NET_SOURCES}

--- a/newlib/libc/sys/vita/Makefile.in
+++ b/newlib/libc/sys/vita/Makefile.in
@@ -95,7 +95,8 @@ am_lib_a_OBJECTS = lib_a-syscalls.$(OBJEXT) lib_a-access.$(OBJEXT) \
 	lib_a-basename.$(OBJEXT) lib_a-dirname.$(OBJEXT) \
 	lib_a-resource.$(OBJEXT) lib_a-sysconf.$(OBJEXT) \
 	lib_a-ids.$(OBJEXT) lib_a-secure_getenv.$(OBJEXT) \
-	lib_a-pipe.$(OBJEXT) lib_a-utime.$(OBJEXT) $(am__objects_1) \
+	lib_a-pipe.$(OBJEXT) lib_a-utime.$(OBJEXT) \
+	lib_a-fcntl.$(OBJEXT) $(am__objects_1) \
 	$(am__objects_2)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@
@@ -497,6 +498,12 @@ lib_a-pipe.o: pipe.c
 
 lib_a-pipe.obj: pipe.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-pipe.obj `if test -f 'pipe.c'; then $(CYGPATH_W) 'pipe.c'; else $(CYGPATH_W) '$(srcdir)/pipe.c'; fi`
+
+lib_a-fcntl.o: fcntl.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-fcntl.o `test -f 'fcntl.c' || echo '$(srcdir)/'`fcntl.c
+
+lib_a-fcntl.obj: fcntl.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-fcntl.obj `if test -f 'fcntl.c'; then $(CYGPATH_W) 'fcntl.c'; else $(CYGPATH_W) '$(srcdir)/fcntl.c'; fi`
 
 lib_a-utime.o: utime.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-utime.o `test -f 'utime.c' || echo '$(srcdir)/'`utime.c

--- a/newlib/libc/sys/vita/dup.c
+++ b/newlib/libc/sys/vita/dup.c
@@ -27,7 +27,7 @@ DEALINGS IN THE SOFTWARE.
 
 int dup(int oldfd)
 {
-	int fd = __vita_duplicate_descriptor(oldfd);
+	int fd = __vita_duplicate_descriptor(oldfd, 0);
 
 	if (fd < 0)
 	{

--- a/newlib/libc/sys/vita/fcntl.c
+++ b/newlib/libc/sys/vita/fcntl.c
@@ -1,0 +1,120 @@
+/*
+
+Copyright (c) 2023 vitasdk
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <sys/socket.h>
+
+#include <psp2/net/net.h>
+#include <psp2/types.h>
+
+#include "vitadescriptor.h"
+#include "vitaerror.h"
+#include "vitanet.h"
+
+int _fcntl_r(struct _reent *reent, int fd, int cmd, ...)
+{
+	int arg = 0;
+	if ((cmd == F_DUPFD) || (cmd == F_SETFD) || (cmd == F_SETFL))
+	{
+		va_list args;
+		va_start(args, cmd);
+		arg = va_arg(args, int);
+		va_end(args);
+	}
+
+	if (cmd == F_DUPFD) {
+		if (arg < 0 || arg >= MAX_OPEN_FILES) {
+			errno = EINVAL;
+			return -1;
+		}
+
+		int dupfd = __vita_duplicate_descriptor(fd, arg);
+		if (dupfd < 0)
+		{
+			errno = EBADF;
+			return -1;
+		}
+
+		errno = 0;
+		return dupfd;
+	}
+
+	DescriptorTranslation *fdmap = __vita_fd_grab(fd);
+	if (fdmap == NULL)
+	{
+		errno = EBADF;
+		return -1;
+	}
+
+	// The only existing flag is FD_CLOEXEC, and it is unsupported,
+	// so F_GETFD always returns zero.
+	if (cmd == F_GETFD)
+	{
+		__vita_fd_drop(fdmap);
+		return 0;
+	}
+
+	// Only net sockets are supported for F_GETFL/F_SETFL
+	if (fdmap->type == VITA_DESCRIPTOR_SOCKET)
+	{
+		if (cmd == F_GETFL)
+		{
+			int optval = 0;
+			socklen_t optlen = sizeof(optval);
+			int res = sceNetGetsockopt(fdmap->sce_uid, SOL_SOCKET, SO_NONBLOCK, &optval, &optlen);
+
+			__vita_fd_drop(fdmap);
+			if (res < 0)
+			{
+				errno = __vita_scenet_errno_to_errno(res);
+				return -1;
+			}
+
+			return (optval) ? O_NONBLOCK : 0;
+		}
+
+		if (cmd == F_SETFL)
+		{
+			int optval = (arg & O_NONBLOCK) ? 1 : 0;
+			socklen_t optlen = sizeof(optval);
+
+			int optres = sceNetSetsockopt(fdmap->sce_uid, SOL_SOCKET, SO_NONBLOCK, &optval, optlen);
+
+			__vita_fd_drop(fdmap);
+			if (optres < 0)
+			{
+				errno = __vita_scenet_errno_to_errno(optres);
+				return -1;
+			}
+
+			return 0;
+		}
+	}
+
+	__vita_fd_drop(fdmap);
+	errno = ENOTSUP;
+	return -1;
+}

--- a/newlib/libc/sys/vita/io.c
+++ b/newlib/libc/sys/vita/io.c
@@ -134,7 +134,7 @@ int __vita_release_descriptor(int fd)
 	return res;
 }
 
-int __vita_duplicate_descriptor(int fd)
+int __vita_duplicate_descriptor(int fd, int minfd)
 {
 	int fd2 = -1;
 
@@ -142,9 +142,11 @@ int __vita_duplicate_descriptor(int fd)
 
 	if (is_fd_valid(fd))
 	{
+
 		// get free descriptor
 		// only allocate descriptors after stdin/stdout/stderr -> aka 0/1/2
-		for (fd2 = 3; fd2 < MAX_OPEN_FILES; ++fd2)
+		minfd = (minfd < 3) ? 3 : minfd;
+		for (fd2 = minfd; fd2 < MAX_OPEN_FILES; ++fd2)
 		{
 			if (__vita_fdmap[fd2] == NULL)
 			{

--- a/newlib/libc/sys/vita/pipe.c
+++ b/newlib/libc/sys/vita/pipe.c
@@ -67,7 +67,7 @@ int pipe(int pipefd[2])
     __vita_fdmap[fd]->sce_uid = ret;
     __vita_fdmap[fd]->type = VITA_DESCRIPTOR_PIPE;
 
-    int fd2 = __vita_duplicate_descriptor(fd);
+    int fd2 = __vita_duplicate_descriptor(fd, 0);
     if (fd2 < 0)
     {
         sceKernelDeleteMsgPipe(ret);

--- a/newlib/libc/sys/vita/socket.c
+++ b/newlib/libc/sys/vita/socket.c
@@ -512,39 +512,50 @@ int	socketpair(int domain, int type, int protocol, int sockfds[2])
 	server_addr.sin_port = 0;
 
 	if (bind(listener, (struct sockaddr*)&server_addr, addr_len) == -1) {
+		int save_errno = errno;
 		close(listener);
+		errno = save_errno;
 		return -1;
 	}
 
 	if (listen(listener, 1) == -1) {
+		int save_errno = errno;
 		close(listener);
+		errno = save_errno;
 		return -1;
 	}
 
 	if (getsockname(listener, (struct sockaddr *)&server_addr, &addr_len) == -1) {
+		int save_errno = errno;
 		close(listener);
+		errno = save_errno;
 		return -1;
 	}
 
 	if ((sockfds[1] = socket(AF_INET, type, protocol)) == -1) {
+		int save_errno = errno;
 		close(listener);
+		errno = save_errno;
 		return -1;
 	}
 
 	if (connect(sockfds[1], (struct sockaddr*)&server_addr, addr_len) == -1) {
+		int save_errno = errno;
 		close(sockfds[1]);
 		close(listener);
+		errno = save_errno;
 		return -1;
 	}
 
 	if ((sockfds[0] = accept(listener, (struct sockaddr*)&server_addr, &addr_len)) == -1) {
+		int save_errno = errno;
 		close(sockfds[1]);
 		close(listener);
+		errno = save_errno;
 		return -1;
 	}
 
 	close(listener);
-
 	return 0;
 }
 #endif

--- a/newlib/libc/sys/vita/vitadescriptor.h
+++ b/newlib/libc/sys/vita/vitadescriptor.h
@@ -50,7 +50,7 @@ extern DescriptorTranslation *__vita_fdmap[];
 
 int __vita_acquire_descriptor(void);
 int __vita_release_descriptor(int fd);
-int __vita_duplicate_descriptor(int fd);
+int __vita_duplicate_descriptor(int fd, int minfd);
 int __vita_descriptor_ref_count(int fd);
 DescriptorTranslation *__vita_fd_grab(int fd);
 int __vita_fd_drop(DescriptorTranslation *fdmap);


### PR DESCRIPTION
- Fixed error handling in `socketpair`. I forgot that `close` calls reset `errno`, so now we're caching it in a var and restoring after `close`
- `pipe2` now also sets linger to zero for underlying sockets. Why? Due to how TCP works after a TCP socket is closed, the closing part of the pair remains in `TIME_WAIT` for 60 seconds, meaning if too many pipes/socketpairs are created too fast, they deplete kernel memory for the buffers.
- `pipe2` always creates socketpair now and doesn't fallback to `pipe` for non-block. This is done for consistency - so that the consumer can use `fcntl` to switch non-block state and it works regardless of how pipe was created (but only for `pipe2` call)
- Implemented `fcntl` for `F_DUPFD`, `F_GETFD` (always 0 since there's no process API and no cloexec), `F_GETFL` and `F_SETFL` & `O_NONBLOCK` for socket fds.

Regarding `F_DUPFD` - I wanted to respect the argument, but taking into account that `MAX_OPEN_FILES` is defined as 256, and `F_DUPFD` arg is usually used to set it above 256, do we really need that? Or can we just ignore the arg and yolo delegate to `dup` call?