### PR TITLE
Fix for GCC14

### DIFF
--- a/newlib/libc/sys/vita/dirent.c
+++ b/newlib/libc/sys/vita/dirent.c
@@ -22,7 +22,7 @@ DEALINGS IN THE SOFTWARE.
 
 */
 
-#include <sys/dirent.h>
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <malloc.h>

--- a/newlib/libc/sys/vita/pipe.c
+++ b/newlib/libc/sys/vita/pipe.c
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.
 #include <sys/socket.h>
 #include <string.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include <psp2/types.h>
 #include <psp2/kernel/threadmgr.h>

--- a/newlib/libc/sys/vita/socket.c
+++ b/newlib/libc/sys/vita/socket.c
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.
 #include <stdlib.h>
 #include <string.h>
 #include <netinet/in.h>
+#include <unistd.h>
 
 #include <psp2/net/net.h>
 #include <psp2/types.h>


### PR DESCRIPTION
GCC14 errors about some functions not explicitly included like close in pipe.c and socket.c
dirent.c didn't like <sys/dirent.h> but <dirent.h> is ok and it compiles.
"sys/dirent.h" should also work

This shouldn't break compilation on GCC lower than 14