### PR TITLE
Don't call a sceKernelDelayThread in usleep when useconds == 0.

### DIFF
--- a/newlib/libc/sys/vita/usleep.c
+++ b/newlib/libc/sys/vita/usleep.c
@@ -29,5 +29,7 @@ DEALINGS IN THE SOFTWARE.
 
 int usleep(unsigned useconds)
 {
-	return sceKernelDelayThread(useconds);
+	if (useconds > 0)
+		sceKernelDelayThread(useconds);
+	return 0;
 }


### PR DESCRIPTION
Performing this call not only will error but will cause, on devkit, a flood of syscall error usage logs, resulting in performance degradation.