### PR TITLE
Fix getnameinfo declaration

### DIFF
--- a/newlib/libc/sys/vita/include/netdb.h
+++ b/newlib/libc/sys/vita/include/netdb.h
@@ -116,7 +116,7 @@ struct hostent *gethostbyaddr(const void *addr, socklen_t len, int type);
 struct servent *getservbyname(const char *name, const char *proto);
 int getaddrinfo(const char *node, const char *service, const struct addrinfo *hints, struct addrinfo **res);
 void freeaddrinfo(struct addrinfo *res);
-int getnameinfo(const struct sockaddr *restrict addr, socklen_t addrlen, char* host, socklen_t hostlen, char* serv, socklen_t servlen,int flags);
+int getnameinfo(const struct sockaddr *__restrict addr, socklen_t addrlen, char* host, socklen_t hostlen, char* serv, socklen_t servlen,int flags);
 const char *gai_strerror(int ecode);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
restrict keyword doesn't exist in C++.

This matches the other declarations in the same folder.