### PR TITLE
sys/vita: Harden __resolve_path against strlcpy collision & handle zero-length socket sends

### DIFF
--- a/newlib/libc/sys/vita/fs.c
+++ b/newlib/libc/sys/vita/fs.c
@@ -310,7 +310,7 @@ char *getcwd(char *buf, size_t size)
 	return buf;
 }
 
-// modified from bionic
+// modified from bionic - hardened with standard ISO C primitives
 char *__resolve_path(const char *path, char resolved[PATH_MAX])
 {
 	char *p, *q, *s;
@@ -323,12 +323,24 @@ char *__resolve_path(const char *path, char resolved[PATH_MAX])
 		if (path[1] == '\0')
 			return (resolved);
 		resolved_len = 1;
-		left_len = strlcpy(left, path + 1, sizeof(left));
+		left_len = strlen(path + 1);
+		if (left_len >= sizeof(left))
+		{
+			errno = ENAMETOOLONG;
+			return (NULL);
+		}
+		memcpy(left, path + 1, left_len + 1);
 	}
 	else
 	{
 		resolved_len = 0;
-		left_len = strlcpy(left, path, sizeof(left));
+		left_len = strlen(path);
+		if (left_len >= sizeof(left))
+		{
+			errno = ENAMETOOLONG;
+			return (NULL);
+		}
+		memcpy(left, path, left_len + 1);
 	}
 	if (left_len >= sizeof(left) || resolved_len >= PATH_MAX)
 	{
@@ -346,14 +358,15 @@ char *__resolve_path(const char *path, char resolved[PATH_MAX])
 		 */
 		p = strchr(left, '/');
 		s = p ? p : left + left_len;
-		if (s - left >= sizeof(next_token))
+		size_t token_len = s - left;
+		if (token_len >= sizeof(next_token))
 		{
 			errno = ENAMETOOLONG;
 			return (NULL);
 		}
-		memcpy(next_token, left, s - left);
-		next_token[s - left] = '\0';
-		left_len -= s - left;
+		memcpy(next_token, left, token_len);
+		next_token[token_len] = '\0';
+		left_len -= token_len;
 		if (p != NULL)
 			memmove(left, s + 1, left_len + 1);
 		if (resolved[resolved_len - 1] != '/')
@@ -387,12 +400,13 @@ char *__resolve_path(const char *path, char resolved[PATH_MAX])
 		/*
 		 * Append the next path component. 
 		 */
-		resolved_len = strlcat(resolved, next_token, PATH_MAX);
-		if (resolved_len >= PATH_MAX)
+		if (resolved_len + token_len >= PATH_MAX)
 		{
 			errno = ENAMETOOLONG;
 			return (NULL);
 		}
+		memcpy(resolved + resolved_len, next_token, token_len + 1);
+		resolved_len += token_len;
 	}
 	/*
 	 * Remove trailing slash except when the resolved pathname

--- a/newlib/libc/sys/vita/socket.c
+++ b/newlib/libc/sys/vita/socket.c
@@ -339,6 +339,10 @@ ssize_t	send(int s, const void *buf, size_t len, int flags)
 		return -1;
 	}
 
+	static const char dummy = 0;
+	if (len == 0 && buf == NULL)
+		buf = &dummy;
+
 	int res = sceNetSend(fdmap->sce_uid, buf, len, flags);
 
 	__vita_fd_drop(fdmap);
@@ -365,6 +369,10 @@ ssize_t	sendto(int s, const void *buf,
 		errno = EBADF;
 		return -1;
 	}
+
+	static const char dummy = 0;
+	if (len == 0 && buf == NULL)
+		buf = &dummy;
 
 	int res = sceNetSendto(fdmap->sce_uid, buf, len, flags, (SceNetSockaddr *)dest_addr, (unsigned int)addrlen);
 


### PR DESCRIPTION
This PR resolves the issues reported in #112:

### 1. `__resolve_path` and `strlcpy`/`strlcat` symbol collision
- Refactored `__resolve_path` in `fs.c` to use standard ISO C string primitives (`strlen`, `memcpy`) instead of `strlcpy` and `strlcat`.
- This isolates internal path canonicalization from any user-defined `strlcpy`/`strlcat` implementations that applications (such as Doom/SRB2 engines or retro game ports) might link against.
- Eliminates (N^2)$ repetitive scans caused by `strlcat` during component appending.

### 2. Zero-length `send()` / `sendto()` with `NULL` buffer
- Added handling for `len == 0 && buf == NULL` in `send()` and `sendto()` (`socket.c`), mapping `buf` to a dummy static byte.
- Prevents `sceNetSend` / `sceNetSendto` from rejecting zero-length probe datagrams with `SCE_NET_EINVAL`.

Fixes #112