### PR TITLE
sys/vita: struct _reent in native ELF TLS, thread-exit reclaim, __cxa_thread_atexit

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -652,7 +652,7 @@ newlib_cflags="${newlib_cflags} -DCLOCK_PROVIDED -DMALLOC_PROVIDED -DEXIT_PROVID
 	;;
   arm*vita*)
 	syscall_dir=syscalls
-	newlib_cflags="${newlib_cflags} -D__DYNAMIC_REENT__ -DREENTRANT_SYSCALLS_PROVIDED -DGETREENT_PROVIDED -DHAVE_FCNTL"
+	newlib_cflags="${newlib_cflags} -DREENTRANT_SYSCALLS_PROVIDED -DHAVE_FCNTL"
 	;;
   arm*-*-pe)
 	syscall_dir=syscalls

--- a/newlib/libc/reent/reent.c
+++ b/newlib/libc/reent/reent.c
@@ -56,9 +56,17 @@ _reclaim_reent (struct _reent *ptr)
 	    }    
 
 	  _free_r (ptr, _REENT_MP_FREELIST(ptr));
+#ifdef _REENT_THREAD_LOCAL
+	  _REENT_MP_FREELIST(ptr) = NULL;
+#endif
 	}
       if (_REENT_MP_RESULT(ptr))
-	_free_r (ptr, _REENT_MP_RESULT(ptr));
+	{
+	  _free_r (ptr, _REENT_MP_RESULT(ptr));
+#ifdef _REENT_THREAD_LOCAL
+	  _REENT_MP_RESULT(ptr) = NULL;
+#endif
+	}
       if (_REENT_MP_P5S(ptr))
         {
           struct _Bigint *thisone, *nextone;
@@ -69,6 +77,9 @@ _reclaim_reent (struct _reent *ptr)
              nextone = nextone->_next;
              _free_r (ptr, thisone);
            }
+#ifdef _REENT_THREAD_LOCAL
+          _REENT_MP_P5S(ptr) = NULL;
+#endif
         }
 #ifdef _REENT_SMALL
       }
@@ -92,7 +103,12 @@ _reclaim_reent (struct _reent *ptr)
 #endif
 
       if (_REENT_CVTBUF(ptr))
-	_free_r (ptr, _REENT_CVTBUF(ptr));
+	{
+	  _free_r (ptr, _REENT_CVTBUF(ptr));
+#ifdef _REENT_THREAD_LOCAL
+	  _REENT_CVTBUF(ptr) = NULL;
+#endif
+	}
     /* We should free _sig_func to avoid a memory leak, but how to
 	   do it safely considering that a signal may be delivered immediately
 	   after the free?
@@ -104,6 +120,9 @@ _reclaim_reent (struct _reent *ptr)
 	  /* cleanup won't reclaim memory 'coz usually it's run
 	     before the program exits, and who wants to wait for that? */
 	  _REENT_CLEANUP(ptr) (ptr);
+#ifdef _REENT_THREAD_LOCAL
+	  _REENT_CLEANUP(ptr) = NULL;
+#endif
 	}
 
       /* Malloc memory not reclaimed; no good way to return memory anyway. */

--- a/newlib/libc/stdio/remove.c
+++ b/newlib/libc/stdio/remove.c
@@ -65,10 +65,10 @@ _remove_r (struct _reent *ptr,
        const char *filename)
 {
   if (_unlink_r (ptr, filename) != -1) return 0;
-  if (ptr->_errno != EISDIR) return -1;
+  if (_REENT_ERRNO (ptr) != EISDIR) return -1;
   if (rmdir(filename) == -1)
   {
-      ptr->_errno = errno;
+      _REENT_ERRNO (ptr) = errno;
       return -1;
   }
   return 0;

--- a/newlib/libc/sys/vita/chroot.c
+++ b/newlib/libc/sys/vita/chroot.c
@@ -29,6 +29,6 @@ DEALINGS IN THE SOFTWARE.
 int chroot(const char *path)
 {
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }

--- a/newlib/libc/sys/vita/groups.c
+++ b/newlib/libc/sys/vita/groups.c
@@ -30,21 +30,21 @@ DEALINGS IN THE SOFTWARE.
 int initgroups(const char *user, gid_t group)
 {
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }
 
 int getgroups(int size, gid_t list[])
 {
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }
 
 int setgroups(size_t size, const gid_t *list)
 {
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }
 
@@ -52,7 +52,7 @@ struct group *getgrent()
 {
 	/* TODO: implement. */
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return NULL;
 }
 
@@ -70,7 +70,7 @@ struct group *getgrnam(const char *name)
 {
 	/* TODO: implement. */
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return NULL;
 }
 
@@ -78,7 +78,7 @@ struct group *getgrgid(gid_t gid)
 {
 	/* TODO: implement. */
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return NULL;
 }
 
@@ -86,6 +86,6 @@ int setpgrp(pid_t pid, pid_t pgid)
 {
 	/* TODO: implement. */
 	struct _reent *reent = _REENT;
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }

--- a/newlib/libc/sys/vita/sbrk.c
+++ b/newlib/libc/sys/vita/sbrk.c
@@ -19,7 +19,7 @@ void * _sbrk_r(struct _reent *reent, ptrdiff_t incr)
 	{
 		sceKernelUnlockLwMutex(&_newlib_sbrk_mutex, 1);
 fail:
-		reent->_errno = ENOMEM;
+		_REENT_ERRNO(reent) = ENOMEM;
 		return (void*) -1;
 	}
 

--- a/newlib/libc/sys/vita/sys/errno.h
+++ b/newlib/libc/sys/vita/sys/errno.h
@@ -10,17 +10,23 @@ extern "C" {
 
 #include <sys/reent.h>
 
+#ifdef _REENT_THREAD_LOCAL
+#define errno (_tls_errno)
+#else /* _REENT_THREAD_LOCAL */
+
 #ifndef _REENT_ONLY
 #define errno (*__errno())
 extern int *__errno (void);
 #endif
+
+#endif /* _REENT_THREAD_LOCAL */
 
 /* Please don't use these variables directly.
    Use strerror instead. */
 extern const char * const _sys_errlist[];
 extern int _sys_nerr;
 
-#define __errno_r(ptr) ((ptr)->_errno)
+#define __errno_r(ptr) _REENT_ERRNO(ptr)
 
 #define EPERM		1	/* Not owner */
 #define ENOENT		2	/* No such file or directory */

--- a/newlib/libc/sys/vita/sys/features.h
+++ b/newlib/libc/sys/vita/sys/features.h
@@ -25,6 +25,9 @@
 extern "C" {
 #endif
 
+/* Must precede <sys/config.h>, which needs _WANT_REENT_THREAD_LOCAL. */
+#include <newlib.h>
+
 #include <_newlib_version.h>
 
 /* Macro to test version of GCC.  Returns 0 for non-GCC or too old GCC. */

--- a/newlib/libc/sys/vita/sys/vita_thread.h
+++ b/newlib/libc/sys/vita/sys/vita_thread.h
@@ -1,0 +1,23 @@
+#ifndef _SYS_VITA_THREAD_H
+#define _SYS_VITA_THREAD_H
+
+/* 1: newlib owns a kernel TLS slot holding the per-thread pointers the thread
+   library needs. 0: it owns no per-thread state and the thread library holds
+   its own slot. Set here and not on the command line: newlib and everything
+   built against it must agree, and only the installed header guarantees it. */
+#define __VITA_NEWLIB_THREAD_SLOT__ 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Exit the calling thread, reclaiming its newlib TLS-resident buffers first.
+   Nothing can reach those from outside once the thread is gone. */
+int vita_exit_thread(int exit_status);
+int vita_exit_delete_thread(int exit_status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _SYS_VITA_THREAD_H */

--- a/newlib/libc/sys/vita/sys/vita_thread.h
+++ b/newlib/libc/sys/vita/sys/vita_thread.h
@@ -5,7 +5,7 @@
    library needs. 0: it owns no per-thread state and the thread library holds
    its own slot. Set here and not on the command line: newlib and everything
    built against it must agree, and only the installed header guarantees it. */
-#define __VITA_NEWLIB_THREAD_SLOT__ 1
+#define __VITA_NEWLIB_OWNS_THREAD_SLOT__ 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/newlib/libc/sys/vita/syscalls.c
+++ b/newlib/libc/sys/vita/syscalls.c
@@ -33,7 +33,7 @@ _write_r(struct _reent * reent, int fd, const void *buf, size_t nbytes)
 	DescriptorTranslation *fdmap = __vita_fd_grab(fd);
 
 	if (!fdmap) {
-		reent->_errno = EBADF;
+		_REENT_ERRNO(reent) = EBADF;
 		return -1;
 	}
 
@@ -67,11 +67,11 @@ _write_r(struct _reent * reent, int fd, const void *buf, size_t nbytes)
 
 	if (ret < 0) {
 		if (ret != -1)
-			reent->_errno = __vita_sce_errno_to_errno(ret, type);
+			_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, type);
 		return -1;
 	}
 
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return ret;
 }
 
@@ -90,11 +90,11 @@ _close_r(struct _reent *reent, int fd)
 
 	if (res < 0)
 	{
-		reent->_errno = EBADF;
+		_REENT_ERRNO(reent) = EBADF;
 		return -1;
 	}
 
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }
 
@@ -102,21 +102,21 @@ int
 _execve_r(struct _reent *reent, const char *name, char * const *argv,
 		char * const *env)
 {
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }
 
 int
 _fork_r(struct _reent *reent)
 {
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }
 
 int
 _getpid_r(struct _reent *reent)
 {
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return sceKernelGetProcessId();
 }
 
@@ -125,10 +125,10 @@ _gettimeofday_r(struct _reent *reent, struct timeval *ptimeval, void *ptimezone)
 {
 	int ret = sceKernelLibcGettimeofday((SceKernelTimeval*)ptimeval, (SceKernelTimezone *)ptimezone);
 	if (ret < 0) {
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }
 
@@ -138,7 +138,7 @@ _isatty_r(struct _reent *reent, int fd)
 	DescriptorTranslation *fdmap = __vita_fd_grab(fd);
 
 	if (!fdmap) {
-		reent->_errno = EBADF;
+		_REENT_ERRNO(reent) = EBADF;
 		return 0;
 	}
 
@@ -153,7 +153,7 @@ _kill_r(struct _reent *reent, int pid, int sig)
 {
 	if (pid != sceKernelGetProcessId())
 	{
-		reent->_errno = EPERM;
+		_REENT_ERRNO(reent) = EPERM;
 		return -1;
 	}
 	switch (sig)
@@ -174,7 +174,7 @@ _kill_r(struct _reent *reent, int pid, int sig)
 int
 _link_r(struct _reent *reent, const char *existing, const char *new)
 {
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }
 
@@ -201,7 +201,7 @@ _lseek_r(struct _reent *reent, int fd, _off_t ptr, int dir)
 
 	if (ret < 0)
 	{
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 
@@ -215,17 +215,17 @@ _mkdir_r (struct _reent * reent, const char * path, int mode)
 	char* full_path = __realpath(path);
 	if(!full_path)
 	{
-		reent->_errno = errno; // set by realpath
+		_REENT_ERRNO(reent) = errno; // set by realpath
 		return -1;
 	}
 	if ((ret = sceIoMkdir(full_path, 0777)) < 0)
 	{
 		free(full_path);
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 	free(full_path);
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }
 
@@ -263,7 +263,7 @@ _open_r(struct _reent *reent, const char *file, int flags, int mode)
 	char* full_path = __realpath(file);
 	if (!full_path)
 	{
-		reent->_errno = errno; // set by realpath
+		_REENT_ERRNO(reent) = errno; // set by realpath
 		return -1;
 	}
 
@@ -276,7 +276,7 @@ _open_r(struct _reent *reent, const char *file, int flags, int mode)
 	if (flags & O_DIRECTORY && !is_dir)
 	{
 		free(full_path);
-		reent->_errno = ENOTDIR;
+		_REENT_ERRNO(reent) = ENOTDIR;
 		return -1;
 	}
 
@@ -284,7 +284,7 @@ _open_r(struct _reent *reent, const char *file, int flags, int mode)
 	if (ret < 0)
 	{
 		free(full_path);
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 
@@ -295,7 +295,7 @@ _open_r(struct _reent *reent, const char *file, int flags, int mode)
 	{
 		free(full_path);
 		is_dir ? sceIoDclose(ret) : sceIoClose(ret);
-		reent->_errno = EMFILE;
+		_REENT_ERRNO(reent) = EMFILE;
 		return -1;
 	}
 
@@ -306,7 +306,7 @@ _open_r(struct _reent *reent, const char *file, int flags, int mode)
 
 	free(full_path);
 
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return fd;
 }
 
@@ -319,7 +319,7 @@ _read_r(struct _reent *reent, int fd, void *ptr, size_t len)
 
 	if (!fdmap)
 	{
-		reent->_errno = EBADF;
+		_REENT_ERRNO(reent) = EBADF;
 		return -1;
 	}
 
@@ -352,18 +352,18 @@ _read_r(struct _reent *reent, int fd, void *ptr, size_t len)
 	if (ret < 0)
 	{
 		if (ret != -1)
-			reent->_errno = __vita_sce_errno_to_errno(ret, type);
+			_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, type);
 		return -1;
 	}
 
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return ret;
 }
 
 int
 _readlink_r(struct _reent *reent, const char *path, char *buf, size_t bufsize)
 {
-	reent->_errno = ENOSYS;
+	_REENT_ERRNO(reent) = ENOSYS;
 	return -1;
 }
 
@@ -374,18 +374,18 @@ _unlink_r(struct _reent *reent, const char * path)
 	char* full_path = __realpath(path);
 	if (!full_path)
 	{
-		reent->_errno = errno; // set by realpath
+		_REENT_ERRNO(reent) = errno; // set by realpath
 		return -1;
 	}
 	ret = sceIoRemove(full_path);
 	if (ret < 0)
 	{
 		free(full_path);
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 	free(full_path);
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }
 
@@ -396,14 +396,14 @@ _rename_r(struct _reent *reent, const char *old, const char *new)
 	char* full_path_old = __realpath(old);
 	if (!full_path_old)
 	{
-		reent->_errno = errno; // set by realpath
+		_REENT_ERRNO(reent) = errno; // set by realpath
 		return -1;
 	}
 	char* full_path_new = __realpath(new);
 	if (!full_path_new)
 	{
 		free(full_path_old);
-		reent->_errno = errno; // set by realpath
+		_REENT_ERRNO(reent) = errno; // set by realpath
 		return -1;
 	}
 
@@ -412,7 +412,7 @@ _rename_r(struct _reent *reent, const char *old, const char *new)
 	{
 		free(full_path_old);
 		free(full_path_new);
-		reent->_errno = 0;
+		_REENT_ERRNO(reent) = 0;
 		return 0;
 	}
 
@@ -431,12 +431,12 @@ _rename_r(struct _reent *reent, const char *old, const char *new)
 	{
 		free(full_path_old);
 		free(full_path_new);
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 	free(full_path_old);
 	free(full_path_new);
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }
 
@@ -475,7 +475,7 @@ _fstat_r(struct _reent *reent, int fd, struct stat *st)
 
 	if (!fdmap)
 	{
-		reent->_errno = EBADF;
+		_REENT_ERRNO(reent) = EBADF;
 		return -1;
 	}
 
@@ -496,12 +496,12 @@ _fstat_r(struct _reent *reent, int fd, struct stat *st)
 
 	if (ret < 0)
 	{
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 
 	scestat_to_stat(&stat, st);
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }
 
@@ -513,17 +513,17 @@ _stat_r(struct _reent *reent, const char *path, struct stat *st)
 	char* full_path = __realpath(path);
 	if (!full_path)
 	{
-		reent->_errno = errno; // set by realpath
+		_REENT_ERRNO(reent) = errno; // set by realpath
 		return -1;
 	}
 	if ((ret = sceIoGetstat(full_path, &stat)) < 0)
 	{
 		free(full_path);
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 	free(full_path);
 	scestat_to_stat(&stat, st);
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }

--- a/newlib/libc/sys/vita/threading.c
+++ b/newlib/libc/sys/vita/threading.c
@@ -1,7 +1,12 @@
-// This provides support for __getreent() as well as implementation of our thread-related wrappers
+// Newlib's own reentrancy (struct _reent) lives directly in native ELF TLS
+// now (see --enable-newlib-reent-thread-local), so this file only keeps the
+// per-thread pointer slots pthread-embedded still needs on top of that.
+// Native TLS can't replace those: pte_osThreadCreate writes into a new
+// thread's slot through sceKernelGetThreadTLSAddr(thid, ...) before that
+// thread has even started, and there is no way to reach another thread's
+// TPIDRURO-relative TLS block from outside it, especially pre-start.
 
 #include <reent.h>
-#include <stdio.h>
 #include <string.h>
 
 #include <vitasdk/utils.h>
@@ -12,50 +17,38 @@ void sceClibPrintf(const char *fmt, ...);
 
 #define MAX_THREADS 256
 
-typedef struct reent_for_thread {
+typedef struct thread_ext_data {
 	int thread_id;
-	int needs_reclaim;
 	void *tls_data_ext;
 	void *pthread_data_ext;
-	struct _reent reent;
-} reent_for_thread;
+} thread_ext_data;
 
-static reent_for_thread reent_list[MAX_THREADS];
+static thread_ext_data thread_ext_list[MAX_THREADS];
 static int _newlib_reent_mutex;
-static struct _reent _newlib_global_reent;
 
-#define TLS_REENT_THID_PTR(thid)	sceKernelGetThreadTLSAddr(thid, 0x89)
-#define TLS_REENT_PTR				sceKernelGetTLSAddr(0x89)
-
-#define list_entry(ptr, type, member) \
-	((type *)((char *)(ptr)-(unsigned long)(&((type *)0)->member)))
+#define TLS_EXT_THID_PTR(thid)	sceKernelGetThreadTLSAddr(thid, 0x89)
+#define TLS_EXT_PTR				sceKernelGetTLSAddr(0x89)
 
 int __vita_delete_thread_reent(int thid)
 {
-	struct reent_for_thread *for_thread;
+	struct thread_ext_data **on_tls = NULL;
+	struct thread_ext_data *for_thread;
 
-	// We only need to cleanup if reent is allocated, i.e. if it's on our TLS
-	// We also don't need to clean up the global reent
-	struct _reent **on_tls = NULL;
-	
 	if (thid == 0)
-		on_tls = TLS_REENT_PTR;
+		on_tls = TLS_EXT_PTR;
 	else
-		on_tls = TLS_REENT_THID_PTR(thid);
+		on_tls = TLS_EXT_THID_PTR(thid);
 
-	if (!*on_tls || *on_tls == &_newlib_global_reent)
+	if (!*on_tls)
 		return 0;
 
-	for_thread = list_entry(*on_tls, struct reent_for_thread, reent);
+	for_thread = *on_tls;
 
 	// Remove from TLS
 	*on_tls = 0;
 
-	// Set thread id to zero, which means the reent is free
+	// Set thread id to zero, which means the slot is free
 	for_thread->thread_id = 0;
-
-	// We can't reclaim it here, will be done later in __getreent
-	for_thread->needs_reclaim = 1;
 
 	return 1;
 }
@@ -74,30 +67,22 @@ int vitasdk_delete_thread_reent(int thid)
 
 int _exit_thread_common(int exit_status, int (*exit_func)(int))
 {
-	int res = 0;
-	int ret = 0;
-	int thid = sceKernelGetThreadId();
+	// Reclaim this thread's own newlib TLS-resident buffers (mprec bigints,
+	// _cvtbuf, locale, ...) before its TLS block disappears with it: unlike
+	// the old reent pool, nothing can reach these from outside the thread
+	// once it's gone.
+	_reclaim_reent(NULL);
 
-	// Lock the list because we'll be modifying it
-	sceKernelLockMutex(_newlib_reent_mutex, 1, NULL);
-
-	res = __vita_delete_thread_reent(0);
-
-	ret = exit_func(exit_status);
-
-	if (res)
-	{
-		struct _reent **on_tls = TLS_REENT_PTR;
-		struct reent_for_thread *for_thread = list_entry(*on_tls, struct reent_for_thread, reent);
-
-		for_thread->thread_id = thid;
-
-		// And put it back on TLS
-		*on_tls = &for_thread->reent;
-	}
-
-	sceKernelUnlockMutex(_newlib_reent_mutex, 1);
-	return ret;
+	// Do NOT hold _newlib_reent_mutex across this call: exit_func normally
+	// never returns, which would leave the mutex permanently owned by a
+	// dead thread and deadlock the next vitasdk_get_tls_data/
+	// vitasdk_get_pthread_data/vitasdk_delete_thread_reent call on any
+	// other thread. The thread's slot doesn't need clearing here either -
+	// pte_osThreadDelete already does that via vitasdk_delete_thread_reent
+	// before a normal exit-and-delete, and __vita_clean_thread_ext's
+	// liveness scan reclaims anything left over from threads that exited
+	// without going through it.
+	return exit_func(exit_status);
 }
 
 int vita_exit_thread(int exit_status)
@@ -110,7 +95,7 @@ int vita_exit_delete_thread(int exit_status)
 	return _exit_thread_common(exit_status, sceKernelExitDeleteThread);
 }
 
-static inline void __vita_clean_reent(void)
+static inline void __vita_clean_thread_ext(void)
 {
 	int i;
 	SceKernelThreadInfo info;
@@ -119,127 +104,87 @@ static inline void __vita_clean_reent(void)
 	{
 		info.size = sizeof(SceKernelThreadInfo);
 
-		if (sceKernelGetThreadInfo(reent_list[i].thread_id, &info) < 0)
+		if (sceKernelGetThreadInfo(thread_ext_list[i].thread_id, &info) < 0)
 		{
-			reent_list[i].thread_id = 0;
-			reent_list[i].needs_reclaim = 1;
+			thread_ext_list[i].thread_id = 0;
 		}
 	}
 }
 
-static inline struct reent_for_thread *__vita_allocate_reent(void)
+static inline struct thread_ext_data *__vita_allocate_thread_ext(void)
 {
 	int i;
-	struct reent_for_thread *free_reent = 0;
 
 	for (i = 0; i < MAX_THREADS; ++i)
-		if (reent_list[i].thread_id == 0)
-		{
-			free_reent = &reent_list[i];
-			break;
-		}
+		if (thread_ext_list[i].thread_id == 0)
+			return &thread_ext_list[i];
 
-	return free_reent;
+	return 0;
 }
 
-struct _reent *__getreent_for_thread(int thid)
+static struct thread_ext_data *__vita_thread_ext(int thid)
 {
-	struct reent_for_thread *free_reent = 0;
-	struct _reent *returned_reent = 0;
+	struct thread_ext_data **on_tls = NULL;
+	struct thread_ext_data *slot;
 
-	// A pointer to our reent should be on the TLS
-	struct _reent **on_tls = NULL;
-	
 	if (thid == 0)
-		on_tls = TLS_REENT_PTR;
+		on_tls = TLS_EXT_PTR;
 	else
-		on_tls = TLS_REENT_THID_PTR(thid);	
-	
+		on_tls = TLS_EXT_THID_PTR(thid);
+
 	if (*on_tls)
 	{
 		return *on_tls;
 	}
-  
-  	sceKernelLockMutex(_newlib_reent_mutex, 1, 0);
 
-	// If it's not on the TLS this means the thread doesn't have a reent allocated yet
-	// We allocate one and put a pointer to it on the TLS
-	free_reent = __vita_allocate_reent();
+	sceKernelLockMutex(_newlib_reent_mutex, 1, 0);
 
-	if (!free_reent)
+	// If it's not on the TLS this means the thread doesn't have a slot
+	// allocated yet. We allocate one and put a pointer to it on the TLS.
+	slot = __vita_allocate_thread_ext();
+
+	if (!slot)
 	{
 		// clean any hanging thread references
-		__vita_clean_reent();
+		__vita_clean_thread_ext();
 
-		free_reent = __vita_allocate_reent();
+		slot = __vita_allocate_thread_ext();
 
-		if (!free_reent)
+		if (!slot)
 		{
 			// we've exhausted all our resources
-			sceClibPrintf("[VITASDK] FATAL: Exhausted all thread reent resources!");
+			sceClibPrintf("[VITASDK] FATAL: Exhausted all thread data resources!");
 			__builtin_trap();
 		}
 	}
-	else
-	{
-		// First, check if it needs to be cleaned up (if it came from another thread)
-		if (free_reent->needs_reclaim)
-		{
-			_reclaim_reent(&free_reent->reent);
-			free_reent->needs_reclaim = 0;
-		}
 
-		memset(free_reent, 0, sizeof(struct reent_for_thread));
-
-		// Set it up
-		if(thid==0)
-		{
-			thid = sceKernelGetThreadId();
-		}
-		free_reent->thread_id = thid;
-		_REENT_INIT_PTR(&free_reent->reent);
-		returned_reent = &free_reent->reent;
-	}
+	memset(slot, 0, sizeof(*slot));
+	slot->thread_id = (thid == 0) ? sceKernelGetThreadId() : thid;
 
 	// Put it on TLS for faster access time
-	*on_tls = returned_reent;
+	*on_tls = slot;
 
 	sceKernelUnlockMutex(_newlib_reent_mutex, 1);
-	return returned_reent;
-}
-
-struct _reent *__getreent(void)
-{
-	return  __getreent_for_thread(0);
+	return slot;
 }
 
 void *vitasdk_get_tls_data(SceUID thid)
 {
-	struct reent_for_thread *for_thread;
-	struct _reent *reent = __getreent_for_thread(thid);
-
-	for_thread = list_entry(reent, struct reent_for_thread, reent);
-	return &for_thread->tls_data_ext;
+	return &__vita_thread_ext(thid)->tls_data_ext;
 }
 
 void *vitasdk_get_pthread_data(SceUID thid)
 {
-	struct reent_for_thread *for_thread;
-	struct _reent *reent = __getreent_for_thread(thid);
-
-	for_thread = list_entry(reent, struct reent_for_thread, reent);
-	return &for_thread->pthread_data_ext;
+	return &__vita_thread_ext(thid)->pthread_data_ext;
 }
 
-// Called from _start to set up the main thread reentrancy structure
+// Called from _start to set up the main thread's slot
 void _init_vita_reent(void)
 {
-	memset(reent_list, 0, sizeof(reent_list));
-	_newlib_reent_mutex = sceKernelCreateMutex("reent list access mutex", 0, 0, 0);
-	reent_list[0].thread_id = sceKernelGetThreadId();
-	_REENT_INIT_PTR(&reent_list[0].reent);
-	*(struct _reent **)(TLS_REENT_PTR) = &reent_list[0].reent;
-	_REENT_INIT_PTR(&_newlib_global_reent);
+	memset(thread_ext_list, 0, sizeof(thread_ext_list));
+	_newlib_reent_mutex = sceKernelCreateMutex("thread ext data access mutex", 0, 0, 0);
+	thread_ext_list[0].thread_id = sceKernelGetThreadId();
+	*(struct thread_ext_data **)(TLS_EXT_PTR) = &thread_ext_list[0];
 }
 
 void _free_vita_reent(void)

--- a/newlib/libc/sys/vita/threading.c
+++ b/newlib/libc/sys/vita/threading.c
@@ -1,7 +1,7 @@
 // Newlib's own reentrancy (struct _reent) lives in native ELF TLS now (see
 // --enable-newlib-reent-thread-local). What is left here is the kernel TLS
 // slot the thread library uses for its per-thread pointers, kept only while
-// __VITA_NEWLIB_THREAD_SLOT__ says newlib is the one that owns it.
+// __VITA_NEWLIB_OWNS_THREAD_SLOT__ says newlib is the one that owns it.
 
 #include <reent.h>
 #include <string.h>
@@ -29,7 +29,7 @@ int vita_exit_delete_thread(int exit_status)
 	return _exit_thread_common(exit_status, sceKernelExitDeleteThread);
 }
 
-#if __VITA_NEWLIB_THREAD_SLOT__
+#if __VITA_NEWLIB_OWNS_THREAD_SLOT__
 
 #include <vitasdk/utils.h>
 
@@ -183,7 +183,7 @@ void _free_vita_reent(void)
 	sceKernelDeleteMutex(_newlib_reent_mutex);
 }
 
-#else /* !__VITA_NEWLIB_THREAD_SLOT__ */
+#else /* !__VITA_NEWLIB_OWNS_THREAD_SLOT__ */
 
 void _init_vita_reent(void)
 {

--- a/newlib/libc/sys/vita/threading.c
+++ b/newlib/libc/sys/vita/threading.c
@@ -4,14 +4,54 @@
 // __VITA_NEWLIB_OWNS_THREAD_SLOT__ says newlib is the one that owns it.
 
 #include <reent.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <sys/vita_thread.h>
 #include <psp2/kernel/threadmgr.h>
 
+struct _thread_dtor {
+	void (*fn)(void *);
+	void *obj;
+	struct _thread_dtor *next;
+};
+
+static _Thread_local struct _thread_dtor *_thread_dtors;
+
+static void _run_thread_dtors(void)
+{
+	while (_thread_dtors) {
+		struct _thread_dtor *d = _thread_dtors;
+		_thread_dtors = d->next;
+		d->fn(d->obj);
+		free(d);
+	}
+}
+
+// C++ ABI: thread_local destructors, run when this thread exits or at exit()
+int __cxa_thread_atexit(void (*fn)(void *), void *obj, void *dso)
+{
+	static int at_exit_registered;
+	struct _thread_dtor *d = malloc(sizeof *d);
+
+	(void)dso;
+	if (!d)
+		return -1;
+	d->fn = fn;
+	d->obj = obj;
+	d->next = _thread_dtors;
+	_thread_dtors = d;
+	if (!at_exit_registered) {
+		at_exit_registered = 1;
+		atexit(_run_thread_dtors);
+	}
+	return 0;
+}
+
 // the stdio cleanup hook closes every stream in the process: that is exit()'s job
 static void _reclaim_thread_reent(void)
 {
+	_run_thread_dtors();
 	_REENT_CLEANUP(_REENT) = NULL;
 	_reclaim_reent(NULL);
 }

--- a/newlib/libc/sys/vita/threading.c
+++ b/newlib/libc/sys/vita/threading.c
@@ -1,16 +1,37 @@
-// Newlib's own reentrancy (struct _reent) lives directly in native ELF TLS
-// now (see --enable-newlib-reent-thread-local), so this file only keeps the
-// per-thread pointer slots pthread-embedded still needs on top of that.
-// Native TLS can't replace those: pte_osThreadCreate writes into a new
-// thread's slot through sceKernelGetThreadTLSAddr(thid, ...) before that
-// thread has even started, and there is no way to reach another thread's
-// TPIDRURO-relative TLS block from outside it, especially pre-start.
+// Newlib's own reentrancy (struct _reent) lives in native ELF TLS now (see
+// --enable-newlib-reent-thread-local). What is left here is the kernel TLS
+// slot the thread library uses for its per-thread pointers, kept only while
+// __VITA_NEWLIB_THREAD_SLOT__ says newlib is the one that owns it.
 
 #include <reent.h>
 #include <string.h>
 
-#include <vitasdk/utils.h>
+#include <sys/vita_thread.h>
 #include <psp2/kernel/threadmgr.h>
+
+int _exit_thread_common(int exit_status, int (*exit_func)(int))
+{
+	// The thread's own TLS-resident buffers (mprec bigints, _cvtbuf, locale)
+	// die with its TLS block, so reclaim them while it is still alive.
+	_reclaim_reent(NULL);
+
+	// exit_func normally never returns: hold no lock across it.
+	return exit_func(exit_status);
+}
+
+int vita_exit_thread(int exit_status)
+{
+	return _exit_thread_common(exit_status, sceKernelExitThread);
+}
+
+int vita_exit_delete_thread(int exit_status)
+{
+	return _exit_thread_common(exit_status, sceKernelExitDeleteThread);
+}
+
+#if __VITA_NEWLIB_THREAD_SLOT__
+
+#include <vitasdk/utils.h>
 
 // not in sdk
 void sceClibPrintf(const char *fmt, ...);
@@ -63,36 +84,6 @@ int vitasdk_delete_thread_reent(int thid)
 
 	sceKernelUnlockMutex(_newlib_reent_mutex, 1);
 	return res;
-}
-
-int _exit_thread_common(int exit_status, int (*exit_func)(int))
-{
-	// Reclaim this thread's own newlib TLS-resident buffers (mprec bigints,
-	// _cvtbuf, locale, ...) before its TLS block disappears with it: unlike
-	// the old reent pool, nothing can reach these from outside the thread
-	// once it's gone.
-	_reclaim_reent(NULL);
-
-	// Do NOT hold _newlib_reent_mutex across this call: exit_func normally
-	// never returns, which would leave the mutex permanently owned by a
-	// dead thread and deadlock the next vitasdk_get_tls_data/
-	// vitasdk_get_pthread_data/vitasdk_delete_thread_reent call on any
-	// other thread. The thread's slot doesn't need clearing here either -
-	// pte_osThreadDelete already does that via vitasdk_delete_thread_reent
-	// before a normal exit-and-delete, and __vita_clean_thread_ext's
-	// liveness scan reclaims anything left over from threads that exited
-	// without going through it.
-	return exit_func(exit_status);
-}
-
-int vita_exit_thread(int exit_status)
-{
-	return _exit_thread_common(exit_status, sceKernelExitThread);
-}
-
-int vita_exit_delete_thread(int exit_status)
-{
-	return _exit_thread_common(exit_status, sceKernelExitDeleteThread);
 }
 
 static inline void __vita_clean_thread_ext(void)
@@ -191,3 +182,15 @@ void _free_vita_reent(void)
 {
 	sceKernelDeleteMutex(_newlib_reent_mutex);
 }
+
+#else /* !__VITA_NEWLIB_THREAD_SLOT__ */
+
+void _init_vita_reent(void)
+{
+}
+
+void _free_vita_reent(void)
+{
+}
+
+#endif

--- a/newlib/libc/sys/vita/threading.c
+++ b/newlib/libc/sys/vita/threading.c
@@ -9,11 +9,18 @@
 #include <sys/vita_thread.h>
 #include <psp2/kernel/threadmgr.h>
 
+// the stdio cleanup hook closes every stream in the process: that is exit()'s job
+static void _reclaim_thread_reent(void)
+{
+	_REENT_CLEANUP(_REENT) = NULL;
+	_reclaim_reent(NULL);
+}
+
 int _exit_thread_common(int exit_status, int (*exit_func)(int))
 {
 	// The thread's own TLS-resident buffers (mprec bigints, _cvtbuf, locale)
 	// die with its TLS block, so reclaim them while it is still alive.
-	_reclaim_reent(NULL);
+	_reclaim_thread_reent();
 
 	// exit_func normally never returns: hold no lock across it.
 	return exit_func(exit_status);
@@ -37,7 +44,7 @@ static SceUID _newlib_reent_exit_handler = -1;
 static int _reclaim_reent_on_exit(SceInt32 type, SceUID thid, SceInt32 arg, void *common)
 {
 	// runs in the exiting thread's context, like SceLibc's own handler
-	_reclaim_reent(NULL);
+	_reclaim_thread_reent();
 	return 0;
 }
 

--- a/newlib/libc/sys/vita/threading.c
+++ b/newlib/libc/sys/vita/threading.c
@@ -29,6 +29,26 @@ int vita_exit_delete_thread(int exit_status)
 	return _exit_thread_common(exit_status, sceKernelExitDeleteThread);
 }
 
+// SCE_KERNEL_THREAD_ID_PROCESS_ALL_ID, only in the kernel headers
+#define _VITA_THREAD_ID_PROCESS_ALL 0x10027
+
+static SceUID _newlib_reent_exit_handler = -1;
+
+static int _reclaim_reent_on_exit(SceInt32 type, SceUID thid, SceInt32 arg, void *common)
+{
+	// runs in the exiting thread's context, like SceLibc's own handler
+	_reclaim_reent(NULL);
+	return 0;
+}
+
+static void _init_vita_reent_reclaim(void)
+{
+	_newlib_reent_exit_handler = sceKernelRegisterThreadEventHandler(
+		"VitaLibcReentReclaim", _VITA_THREAD_ID_PROCESS_ALL,
+		SCE_KERNEL_THREAD_EVENT_TYPE_EXIT, _reclaim_reent_on_exit, NULL);
+	// on failure only the old leak comes back
+}
+
 #if __VITA_NEWLIB_OWNS_THREAD_SLOT__
 
 #include <vitasdk/utils.h>
@@ -176,10 +196,12 @@ void _init_vita_reent(void)
 	_newlib_reent_mutex = sceKernelCreateMutex("thread ext data access mutex", 0, 0, 0);
 	thread_ext_list[0].thread_id = sceKernelGetThreadId();
 	*(struct thread_ext_data **)(TLS_EXT_PTR) = &thread_ext_list[0];
+	_init_vita_reent_reclaim();
 }
 
 void _free_vita_reent(void)
 {
+	// not unregistered: _exit() calls sceKernelExitProcess() right after
 	sceKernelDeleteMutex(_newlib_reent_mutex);
 }
 
@@ -187,6 +209,7 @@ void _free_vita_reent(void)
 
 void _init_vita_reent(void)
 {
+	_init_vita_reent_reclaim();
 }
 
 void _free_vita_reent(void)

--- a/newlib/libc/sys/vita/truncate.c
+++ b/newlib/libc/sys/vita/truncate.c
@@ -42,11 +42,11 @@ int truncate(const char *path, off_t length)
 
 	if (ret < 0)
 	{
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }
 
@@ -61,7 +61,7 @@ int ftruncate(int fd, off_t length)
 
 	if (!fdmap)
 	{
-		reent->_errno = EBADF;
+		_REENT_ERRNO(reent) = EBADF;
 		return -1;
 	}
 
@@ -82,10 +82,10 @@ int ftruncate(int fd, off_t length)
 
 	if (ret < 0)
 	{
-		reent->_errno = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
+		_REENT_ERRNO(reent) = __vita_sce_errno_to_errno(ret, ERROR_GENERIC);
 		return -1;
 	}
 
-	reent->_errno = 0;
+	_REENT_ERRNO(reent) = 0;
 	return 0;
 }


### PR DESCRIPTION
## What does this change?

`struct _reent` moves into native ELF TLS (`--enable-newlib-reent-thread-local`); the kernel-TLS-slot reent pool, `__getreent()` and `__DYNAMIC_REENT__` go. What is left of the kernel slot (the two pointers the thread library needs) sits behind `__VITA_NEWLIB_THREAD_SLOT__` in the new `<sys/vita_thread.h>`, default 1 (as before). A thread's TLS-resident newlib state is reclaimed on every exit path: explicitly through `vita_exit_thread`/`vita_exit_delete_thread`, and from a process-wide `SCE_KERNEL_THREAD_EVENT_TYPE_EXIT` handler registered at init (the same call SceLibc makes), with `_reclaim_reent` made idempotent under thread-local reent and kept away from the stdio cleanup hook, which closes every stream in the process. newlib provides `__cxa_thread_atexit`, running C++ `thread_local` destructors from that same exit path. Also fixed: `<sys/param.h>` reaching `<sys/config.h>` before `<newlib.h>`, which left `hash.o` with an unresolved `_impure_ptr` in the thread-local build.

## Why is this change needed?

Phase B of vitasdk/.github#3. With `--disable-tls`, `__thread` compiles to emulated TLS that degrades to a single process-global slot inside a thread library; newlib carried a 256-entry table with a hard ceiling ending in `__builtin_trap()`; the hardware needs neither. Details, measurements and the review discussion are in the RFC.

## Testing

- Real PlayStation Vita hardware (3.60, 2026-08-30): `newlib-tests`, 88 tests, 82 pass, 0 failures, 6 skips. TLS group: initial values and isolation in raw threads and pthreads, multi-TU relocation, `errno` isolation, concurrent `%f` formatting, thread churn with heap bounds on every exit path (raw return, `sceKernelExitDeleteThread`, `vita_exit_thread` double reclaim, pthread return), C++ `thread_local` construction once per thread and destruction on pthread and raw-thread exit, a destructor calling `snprintf`/`strtod` over 84 threads with a flat heap.
- Vita3K, on a build with a fix for the emulator's thread END handler (it never runs in the released emulator; PR to follow there): 88 tests, 0 failures, 26 consecutive full runs. Earlier runs that looked like emulator hangs were not: the guest had finished, but Vita3K does not exit on its own after `sceKernelExitProcess` in console mode and its file log lags by a 4 KiB buffer, so the end marker sometimes never reached the file before the runner's timeout. The log flush is part of the same Vita3K PR.
- No regressions against the newlib 4.1 baseline of the suite.

## Compatibility

Breaks the target ABI; every package is rebuilt at the series cut, per the RFC. Removed: `__getreent`, `__errno`, `_impure_ptr`, the fields of `struct _reent`; `vitasdk_get_tls_data`, `vitasdk_get_pthread_data`, `vitasdk_delete_thread_reent` remain while the switch is 1 and go with it. Ordinary `errno` and `__thread` code is source-compatible. Requires the toolchain built with `--enable-tls` and the `vita-elf-create` of vitasdk/vita-toolchain#294; libstdc++ must be configured with `HAVE___CXA_THREAD_ATEXIT` for the C++ part (vitasdk/buildscripts#185). RFC: vitasdk/.github#3.

## Third-party material

None.

## AI assistance

- Claude Opus 5
- Claude Sonnet 5
- Claude Fable 5

## Additional context

RFC: vitasdk/.github#3. Companions: vitasdk/pthread-embedded#24, vitasdk/vita-toolchain#294, vitasdk/buildscripts#185. Moving the switch needs a clean rebuild of newlib and pthread-embedded on an incremental tree; the buildscripts PR makes it part of both build identities.
